### PR TITLE
General code quality fix-1

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/CharSequences.java
+++ b/src/main/java/net/openhft/chronicle/values/CharSequences.java
@@ -28,7 +28,7 @@ public final class CharSequences {
         return h;
     }
 
-    public static boolean equals(CharSequence left, CharSequence right) {
+    public static boolean isEqual(CharSequence left, CharSequence right) {
         if (left == null && right == null)
             return true;
         if (left == null || right == null)

--- a/src/main/java/net/openhft/chronicle/values/CodeTemplate.java
+++ b/src/main/java/net/openhft/chronicle/values/CodeTemplate.java
@@ -42,6 +42,10 @@ import static net.openhft.chronicle.values.MethodTemplate.Type.SCALAR;
 
 final class CodeTemplate {
 
+	private CodeTemplate() {
+		
+	}
+	
     public static final Function<Method, Parameter> NO_ANNOTATED_PARAM = m -> null;
 
     private static final SortedSet<MethodTemplate> METHOD_TEMPLATES =

--- a/src/main/java/net/openhft/chronicle/values/FieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/FieldModel.java
@@ -61,11 +61,9 @@ public abstract class FieldModel {
         Align align = m.getAnnotation(Align.class);
         if (align != null) {
             // if both specified
-            if (align.offset() > 0 && align.dontCross() >= 0) {
-                if (align.dontCross() % align.offset() != 0) {
+            if (align.offset() > 0 && align.dontCross() >= 0 && align.dontCross() % align.offset() != 0) {
                     throw new IllegalStateException(align + " dontCross alignment should be " +
                             "a multiple of offset alignment, field " + name);
-                }
             }
             setOffsetAlignmentExplicitly(align.offset());
             dontCrossAlignment = align.dontCross();

--- a/src/main/java/net/openhft/chronicle/values/Generators.java
+++ b/src/main/java/net/openhft/chronicle/values/Generators.java
@@ -36,7 +36,7 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 
 final class Generators {
 
-    private static final boolean dumpCode = Boolean.getBoolean("chronicle.values.dumpCode");
+    private static final boolean DUMP_CODE = Boolean.getBoolean("chronicle.values.dumpCode");
 
     static String generateNativeClass(ValueModel model, String nativeClassName) {
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(nativeClassName);
@@ -50,7 +50,7 @@ final class Generators {
                 .builder(model.valueType.getPackage().getName(), nativeType)
                 .build()
                 .toString();
-        if (dumpCode)
+        if (DUMP_CODE)
             System.out.println(result);
         return result;
     }
@@ -236,7 +236,7 @@ final class Generators {
                 .builder(model.valueType.getPackage().getName(), heapType)
                 .build()
                 .toString();
-        if (dumpCode)
+        if (DUMP_CODE)
             System.out.println(result);
         return result;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1201 - Methods named "equals" should override Object.equals(Object).
squid:S1118 - Utility classes should not have public constructors.
squid:S1066 - Collapsible "if" statements should be merged.
squid:S00115 - Constant names should comply with a naming convention.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1201
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S00115

Please let me know if you have any questions.

Faisal Hameed