### PR TITLE
Generated classes with more than one enum were failing to compile

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/EnumFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/EnumFieldModel.java
@@ -137,8 +137,9 @@ class EnumFieldModel extends IntegerBackedFieldModel {
 
     private String fromOrdinalOrMinusOne(MethodSpec.Builder methodBuilder, String value) {
         if (nullable()) {
-            methodBuilder.addStatement("int ordinal = " + value);
-            return format("ordinal >= 0 ? %s[ordinal] : null", universeName());
+            String ordinalVariableName = name() + "Ordinal";
+            methodBuilder.addStatement(format("int %s = %s", ordinalVariableName, value));
+            return format("%s >= 0 ? %s[%s] : null", ordinalVariableName, universeName(), ordinalVariableName);
         } else {
             return format("%s[%s]", universeName(), value);
         }

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceMoreThanOneEnums.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceMoreThanOneEnums.java
@@ -1,0 +1,32 @@
+/*
+ *     Copyright (C) 2015  higherfrequencytrading.com
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.openhft.chronicle.values;
+
+public interface JavaBeanInterfaceMoreThanOneEnums {
+
+    void setMyEnum1(MyEnum myEnum);
+
+    MyEnum getMyEnum1();
+
+    void setMyEnum2(MyEnum myEnum);
+
+    MyEnum getMyEnum2();
+
+    void setBuySell(BuySell myEnum);
+
+    BuySell getBuySell();
+}

--- a/src/test/java/net/openhft/chronicle/values/ValueGeneratorTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ValueGeneratorTest.java
@@ -224,4 +224,21 @@ public class ValueGeneratorTest {
         jbid.setDate(date);
         assertEquals(date, jbid.getDate());
     }
+
+    @Test
+    public void testGenerateInterfaceWithMoreThanOneEnums()   {
+        //dvg.setDumpCode(true);
+        JavaBeanInterfaceMoreThanOneEnums jbid = newNativeReference(JavaBeanInterfaceMoreThanOneEnums.class);
+        BytesStore bytes = BytesStore.wrap(ByteBuffer.allocate(64));
+        ((Byteable) jbid).bytesStore(bytes, 0L, ((Byteable) jbid).maxSize());
+        MyEnum myEnum1 = MyEnum.B;
+        jbid.setMyEnum1(myEnum1);
+        MyEnum myEnum2 = MyEnum.A;
+        jbid.setMyEnum2(myEnum2);
+        BuySell buySell = BuySell.BUY;
+        jbid.setBuySell(buySell);
+        assertEquals(myEnum1, jbid.getMyEnum1());
+        assertEquals(myEnum2, jbid.getMyEnum2());
+        assertEquals(buySell, jbid.getBuySell());
+    }
 }


### PR DESCRIPTION
If an interface had more than one enum then some methods e.g. readMarshallable were being generated with duplicate variable names. An example error being:

    xxxx.java:llll: error: variable ordinal is already defined in method         
    readMarshallable(net.openhft.chronicle.bytes.BytesIn)
        int ordinal = (int) bytes.readStopBit();
