### PR TITLE
Clarify alignment annotation

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/Align.java
+++ b/src/main/java/net/openhft/chronicle/values/Align.java
@@ -26,57 +26,55 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Specifies the fields' arrangement in native implementation should be so that the offset to the
- * aligned field bytes from the beginning of the instance is a multiple of the specified {@link
- * #offset()}, the range of the field's bytes offsets don't cross the specified {@link #dontCross()}
- * boundary. This annotation should be put on any single method accessing the field: getter, or
- * setter, or adder, etc.
+ * Describes how a field should be aligned in the generated native layout. The field's
+ * start offset is required to be a multiple of {@link #offset()} and its bytes must not
+ * cross the boundary given by {@link #dontCross()}. Put this annotation on one accessor
+ * of the field such as a getter or setter.
  * <p>
- * This annotation guarantees alignment from the beginning of the instance, so to ensure
- * alignment in the native memory, the instance as a whole should be aligned by native memory
- * addresses to the most coarse alignment of it's fields.
+ * Alignment is measured from the beginning of the value instance. To keep the guarantee
+ * when the instance is stored in native memory the instance itself should be aligned to
+ * the coarsest field alignment.
  * <p>
- * The default alignment depends on the field type, see {@link #DEFAULT}.
+ * The default alignment is determined by the field type, see {@link #DEFAULT}.
  */
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
 public @interface Align {
     /**
+     * Rules used when explicit alignment is not provided:
      * <ul>
-     * <li>If the field type is an integer or a floating point primitive, default {@link
-     * #dontCross()} alignment is equivalent to 1-byte for fields which take {@code <=} 8 bits, 2-byte
-     * for fields which take {@code <=} 16 bits, 4-byte for fields which take {@code <=} 32 bits, 8-byte for
-     * fields which take {@code <= } 64 bits. {@link #offset()} alignment is 1-byte for such fields.</li>
-     * <li>If the field is another value interface, default {@code offset} alignment is
-     * {@link ValueModel#recommendedOffsetAlignment()} for this sub-value interface. {@code
-     * dontCross} default alignment for Value fields is {@link #NO_ALIGNMENT}.</li>
-     * <li>If the field is an array, default {@code offset} alignment is equivalent to the
-     * maximum of it's element {@code offset} or {@code dontCross} alignment, default {@code
-     * dontCross} for array fields is {@code NO_ALIGNMENT}.
-     * </li>
-     * <li>If the field is of {@link CharSequence} type, default {@code dontCross} alignment
-     * is {@link #NO_ALIGNMENT}. Default {@code offset} alignment is not applicable for
-     * {@code CharSequence} fields, must be specified explicitly.</li>
-     * <li>If the field is of {@code boolean} type, default alignment is not applicable, both
-     * {@code offset} and {@code dontCross} alignment values must be specified explicitly.</li>
+     * <li>For integer or floating point primitives {@link #dontCross()} defaults to a power
+     * of two large enough for the size of the field, while {@link #offset()} is 1 byte.</li>
+     * <li>For another value interface the {@link #offset()} default comes from
+     * {@link ValueModel#recommendedOffsetAlignment()} and {@code dontCross} defaults to
+     * {@link #NO_ALIGNMENT}.</li>
+     * <li>For arrays the {@code offset} default is the maximum of element {@code offset} and
+     * {@code dontCross} alignments, while {@code dontCross} defaults to {@link #NO_ALIGNMENT}.</li>
+     * <li>For {@link CharSequence} fields {@code dontCross} defaults to {@link #NO_ALIGNMENT} and
+     * {@code offset} has no default.</li>
+     * <li>For {@code boolean} fields no default alignment applies.</li>
      * </ul>
+     * Using {@code DEFAULT} defers to these rules. If a rule yields {@code NO_ALIGNMENT}, the
+     * corresponding check is disabled.
      */
     int DEFAULT = -1;
 
     /**
-     * 0 represents no particular alignment (shouldn't align the field start, shouldn't track
-     * crossing of any border).
+     * No alignment constraints. When this value is used for {@link #offset()} or
+     * {@link #dontCross()} the generator will not enforce alignment for the field.
      */
     int NO_ALIGNMENT = 0;
 
     /**
-     * The offset to the field's bytes should be a multiple of the {@code offset}.
+     * @return alignment in bytes for the field start. {@link #DEFAULT} applies the
+     * type-specific rule which may resolve to {@link #NO_ALIGNMENT}.
      */
     int offset() default DEFAULT;
 
     /**
-     * The field's bytes shouldn't cross the {@code dontCross} boundary.
+     * @return boundary in bytes that the field should not cross. {@link #DEFAULT}
+     * delegates to the rule for the field type and may become {@link #NO_ALIGNMENT}.
      */
     int dontCross() default DEFAULT;
 }


### PR DESCRIPTION
## Summary
- improve explanation of field alignment and instance alignment
- detail behaviour of `offset()` and `dontCross()`
- explain when `DEFAULT` and `NO_ALIGNMENT` disable checks

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*