### PR TITLE
Clarify copy behaviour and clean Javadoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -250,6 +250,10 @@ Generated classes implement:
 * Correct `equals`, `hashCode`, `toString`
 * `Byteable` (no-op on the heap implementation)
 
+The `Copyable` feature allows an on-heap value to take a snapshot of a
+native instance or vice versa. This provides a simple way to shuttle data
+between the two representations.
+
 You may extend these in the interface to avoid casting:
 
 [source,java]

--- a/src/main/java/net/openhft/chronicle/values/Copyable.java
+++ b/src/main/java/net/openhft/chronicle/values/Copyable.java
@@ -19,16 +19,21 @@
 package net.openhft.chronicle.values;
 
 /**
- * User: peter.lawrey
- * Date: 08/10/13
- * Time: 07:45
+ * Marker interface for objects that can copy state from another instance.
+ * <p>
+ * Generated value interfaces exist in both heap and native forms. Invoking
+ * {@code copyFrom} allows an on-heap instance to copy the contents of an
+ * off-heap reference or the other way round.
  */
 @FunctionalInterface
 public interface Copyable<T> {
     /**
-     * Copy from this type.
+     * Copies all fields from the provided instance into {@code this} instance.
+     * Nested values are copied recursively via their own {@code copyFrom}
+     * implementations. Implementations are not inherently thread-safe; callers
+     * must ensure exclusive access to both instances during the operation.
      *
-     * @param from to copy from
+     * @param from source instance
      */
     void copyFrom(T from);
 }

--- a/src/test/java/net/openhft/chronicle/values/GetUsingStringInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/GetUsingStringInterface.java
@@ -19,7 +19,7 @@
 package net.openhft.chronicle.values;
 
 /**
- * User: peter.lawrey Date: 08/10/13 Time: 09:09
+ * Interface exercising getUsing methods with strings.
  */
 public interface GetUsingStringInterface {
 

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsing.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsing.java
@@ -19,7 +19,7 @@
 package net.openhft.chronicle.values;
 
 /**
- * User: peter.lawrey Date: 06/10/13 Time: 16:59
+ * Interface for getUsing behaviour on a simple bean.
  */
 public interface JavaBeanInterfaceGetUsing {
 

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsingHeap.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsingHeap.java
@@ -19,7 +19,7 @@
 package net.openhft.chronicle.values;
 
 /**
- * User: peter.lawrey Date: 06/10/13 Time: 16:59
+ * Variant of JavaBeanInterface using heap-backed implementations.
  */
 public interface JavaBeanInterfaceGetUsingHeap {
 

--- a/src/test/java/net/openhft/chronicle/values/MinimalInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/MinimalInterface.java
@@ -22,9 +22,7 @@ import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.BytesMarshallable;
 
 /**
- * User: peter.lawrey
- * Date: 06/10/13
- * Time: 16:59
+ * Minimal value interface used for code generation tests.
  */
 @SuppressWarnings("rawtypes")
 public interface MinimalInterface extends BytesMarshallable, Copyable<MinimalInterface>, Byteable {

--- a/src/test/java/net/openhft/chronicle/values/NestedA.java
+++ b/src/test/java/net/openhft/chronicle/values/NestedA.java
@@ -18,9 +18,7 @@
 package net.openhft.chronicle.values;
 
 /**
- * User: peter.lawrey
- * Date: 08/10/13
- * Time: 10:11
+ * First level nested interface used in tests.
  */
 public interface NestedA {
     void key(@MaxUtf8Length(64) String key);

--- a/src/test/java/net/openhft/chronicle/values/NestedB.java
+++ b/src/test/java/net/openhft/chronicle/values/NestedB.java
@@ -19,9 +19,7 @@
 package net.openhft.chronicle.values;
 
 /**
- * User: peter.lawrey
- * Date: 08/10/13
- * Time: 10:24
+ * Second level nested interface used in tests.
  */
 public interface NestedB {
     void bid(double bid);

--- a/src/test/java/net/openhft/chronicle/values/StringInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/StringInterface.java
@@ -19,9 +19,7 @@
 package net.openhft.chronicle.values;
 
 /**
- * User: peter.lawrey
- * Date: 08/10/13
- * Time: 09:09
+ * Used for basic string handling tests.
  */
 public interface StringInterface {
     String getString();

--- a/src/test/java/net/openhft/chronicle/values/ValueGeneratorTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ValueGeneratorTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.*;
 import static net.openhft.compiler.CompilerUtils.CACHED_COMPILER;
 
 /**
- * User: peter.lawrey Date: 06/10/13 Time: 20:13
+ * Tests code generation and serialisation routines.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ValueGeneratorTest extends ValuesTestCommon {


### PR DESCRIPTION
## Summary
- remove stale User/Date/Time comments from tests
- document `copyFrom` usage and thread-safety
- mention heap to off-heap copy in README

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*