### PR TITLE
Clarify MaxUtf8Length semantics

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/MaxUtf8Length.java
+++ b/src/main/java/net/openhft/chronicle/values/MaxUtf8Length.java
@@ -26,8 +26,8 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * The maximum length of a CharSequence/String/StringBuilder field in a Chronicle Value, in UTF-8
- * encoding.
+ * Defines the fixed UTF-8 byte size for a CharSequence/String/StringBuilder field.
+ * The {@code value()} method returns this maximum byte length.
  */
 @Target(PARAMETER)
 @Retention(RUNTIME)


### PR DESCRIPTION
## Summary
- document MaxUtf8Length annotation

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*