### PR TITLE
Improve Range annotation docs

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/Range.java
+++ b/src/main/java/net/openhft/chronicle/values/Range.java
@@ -26,13 +26,20 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * The lowest to highest values allowed (inclusive)
+ * Constrains integer primitive parameters to a lowest and highest value,
+ * inclusive.
  */
 @Target(PARAMETER)
 @Retention(RUNTIME)
 @Documented
 public @interface Range {
+    /**
+     * @return the smallest allowed value, inclusive
+     */
     long min() default Long.MIN_VALUE;
 
+    /**
+     * @return the largest allowed value, inclusive
+     */
     long max() default Long.MAX_VALUE;
 }


### PR DESCRIPTION
## Summary
- document Range annotation as a constraint on integer primitives
- document `min()` and `max()` return values

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*