### PR TITLE
Document enum utilities

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -93,6 +93,7 @@ interface Order {
     void setState(@NotNull State state);
 }
 ----
+The generated classes keep a reference to the array of constants for each enum field. The `Enums` helper obtains this array via reflection from `EnumSet.getUniverse(Class)`. Caching the array lets the marshalling code translate ordinals without calling `values()` on every access.
 
 ===== java.util.Date
 

--- a/src/main/java/net/openhft/chronicle/values/Enums.java
+++ b/src/main/java/net/openhft/chronicle/values/Enums.java
@@ -18,6 +18,13 @@
 
 package net.openhft.chronicle.values;
 
+/**
+ * Utility methods used by generated code for enum fields. The generator caches
+ * the array of constants for each enum so that values can be marshalled by
+ * ordinal. The constants array is obtained by reflectively invoking the
+ * package-private {@code EnumSet.getUniverse(Class)} method.
+ */
+
 import net.openhft.chronicle.core.Jvm;
 
 import java.lang.reflect.InvocationTargetException;
@@ -40,6 +47,14 @@ public final class Enums {
     private Enums() {
     }
 
+    /**
+     * Returns the constant array backing the supplied enum type.
+     *
+     * @param enumType the enum class
+     * @param <E>      type of the enum
+     * @return the array returned by {@code EnumSet.getUniverse(Class)}
+     * @throws RuntimeException if reflective access fails
+     */
     public static <E extends Enum<E>> E[] getUniverse(Class<E> enumType) {
         try {
             //noinspection unchecked
@@ -49,6 +64,13 @@ public final class Enums {
         }
     }
 
+    /**
+     * Returns the number of constants declared by the enum.
+     *
+     * @param enumType the enum class
+     * @param <E>      type of the enum
+     * @return constant count
+     */
     public static <E extends Enum<E>> int numberOfConstants(Class<E> enumType) {
         return getUniverse(enumType).length;
     }


### PR DESCRIPTION
## Summary
- document how enum constants are cached
- explain `Enums` helper and its methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*