### PR TITLE
Clarify ImplGenerationFailedException

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/ImplGenerationFailedException.java
+++ b/src/main/java/net/openhft/chronicle/values/ImplGenerationFailedException.java
@@ -19,15 +19,22 @@
 package net.openhft.chronicle.values;
 
 /**
- * Thrown when the Chronicle Values library is not able to generate heap or native implementation
- * for the given interface, i. e. it is not a <i>value interface</i>. This exception thrown for
- * a valid value interface (according to
- * <a href="https://github.com/OpenHFT/Chronicle-Values#value-interface-specification">the
- * specification</a>) might also indicate a bug in the Chronicle Values library.
+ * Thrown when the Chronicle Values library is unable to generate the heap or native
+ * implementation for a particular interface.
+ * <p>
+ * Typical reasons include using an interface that does not obey the
+ * <em>value interface</em> specification or the generated code failing to compile.
+ * If a valid value interface triggers this exception, it is likely an internal
+ * bug in Chronicle Values.
  */
 public final class ImplGenerationFailedException extends RuntimeException {
     private static final long serialVersionUID = 0L;
 
+    /**
+     * Creates a new instance wrapping the underlying cause of the generation failure.
+     *
+     * @param cause the compilation or runtime problem that prevented implementation generation
+     */
     public ImplGenerationFailedException(Throwable cause) {
         super(cause);
     }


### PR DESCRIPTION
## Summary
- document reasons why `ImplGenerationFailedException` may occur
- describe the meaning of the `cause` parameter

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*