### PR TITLE
Document ValuesTestCommon utilities

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/ValuesTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/values/ValuesTestCommon.java
@@ -33,6 +33,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
+/**
+ * Base class for values tests.
+ *
+ * Enables reference tracing and starts exception recording before each test.
+ * At the end of a test it verifies that all resources have been released,
+ * no unexpected threads remain and only declared exceptions were logged.
+ */
+
 public class ValuesTestCommon {
 
     protected ThreadDump threadDump;
@@ -44,6 +52,10 @@ public class ValuesTestCommon {
         AbstractReferenceCounted.enableReferenceTracing();
     }
 
+    /**
+     * Fails the test if any {@code AbstractReferenceCounted} instances have not
+     * reached a reference count of zero.
+     */
     public void assertReferencesReleased() {
         AbstractReferenceCounted.assertReferencesReleased();
     }
@@ -62,18 +74,36 @@ public class ValuesTestCommon {
         exceptions = Jvm.recordExceptions();
     }
 
+    /**
+     * Registers an expected log entry containing the supplied message.
+     */
     public void expectException(String message) {
-        expectException(k -> k.message.contains(message) || (k.throwable != null && k.throwable.getMessage().contains(message)), message);
+        expectException(k -> k.message.contains(message) ||
+                (k.throwable != null &&
+                        k.throwable.getMessage().contains(message)), message);
     }
 
+    /**
+     * Registers an expected log entry that matches the given predicate.
+     *
+     * @param predicate test for matching exception keys
+     * @param description text used if the expected entry is missing
+     */
     public void expectException(Predicate<ExceptionKey> predicate, String description) {
         expectedExceptions.put(predicate, description);
     }
 
+    /**
+     * Verifies that only declared exceptions were recorded during the test.
+     * Any unexpected entry causes the test to fail after dumping the log.
+     */
     public void checkExceptions() {
-        for (Map.Entry<Predicate<ExceptionKey>, String> expectedException : expectedExceptions.entrySet()) {
-            if (!exceptions.keySet().removeIf(expectedException.getKey()))
-                Slf4jExceptionHandler.WARN.on(getClass(), "No error for " + expectedException.getValue());
+        for (Map.Entry<Predicate<ExceptionKey>, String> expectedException :
+                expectedExceptions.entrySet()) {
+            if (!exceptions.keySet().removeIf(expectedException.getKey())) {
+                Slf4jExceptionHandler.WARN.on(getClass(),
+                        "No error for " + expectedException.getValue());
+            }
         }
         expectedExceptions.clear();
         if (Jvm.hasException(exceptions)) {


### PR DESCRIPTION
## Summary
- document the test helper class setup
- describe behaviour of assertReferencesReleased, expectException and checkExceptions

## Testing
- `mvn -q verify` *(fails: mvn not found)*