### PR TITLE
Improve Utils documentation

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/Utils.java
+++ b/src/main/java/net/openhft/chronicle/values/Utils.java
@@ -19,6 +19,10 @@
 package net.openhft.chronicle.values;
 
 final class Utils {
+    /**
+     * Class object for {@code sun.misc.Unsafe}, loaded reflectively to avoid a
+     * hard dependency on that class.
+     */
     static final Class<?> UNSAFE_CLASS;
 
     static {
@@ -32,14 +36,34 @@ final class Utils {
     private Utils() {
     }
 
+    /**
+     * Rounds {@code divident} up to the nearest multiple of {@code divisor}.
+     *
+     * @param divident the value to round
+     * @param divisor  the alignment unit
+     * @return the smallest multiple of {@code divisor} not less than {@code divident}
+     */
     public static int roundUp(int divident, int divisor) {
         return ((divident + divisor - 1) / divisor) * divisor;
     }
 
+    /**
+     * Capitalises the first character of {@code s}.
+     *
+     * @param s the string to alter
+     * @return {@code s} with the first character converted to upper case
+     */
     static String capitalize(String s) {
         return s.substring(0, 1).toUpperCase() + s.substring(1);
     }
 
+    /**
+     * Formats the value for code generation, appending {@code 'L'} if
+     * it does not fit into an {@code int}.
+     *
+     * @param v the value to format
+     * @return decimal representation with an optional {@code 'L'} suffix
+     */
     static String formatIntOrLong(long v) {
         if (v >= Integer.MIN_VALUE && v <= Integer.MAX_VALUE)
             return v + "";


### PR DESCRIPTION
## Summary
- explain the reflective purpose of `UNSAFE_CLASS`
- add Javadoc `@param` and `@return` tags for helper methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*