### PR TITLE
Document generator helper methods

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/Generators.java
+++ b/src/main/java/net/openhft/chronicle/values/Generators.java
@@ -30,11 +30,26 @@ import static java.util.Collections.emptyList;
 import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PUBLIC;
 
+/**
+ * Utility responsible for generating the heap and native implementation
+ * classes for a value interface. Each method produces a block of Java source
+ * code to be compiled later by {@link ValueModel}. Only ASCII characters and
+ * British spelling are used in generated text.
+ */
 final class Generators {
 
     private Generators() {
     }
 
+    /**
+     * Generates the source for the native (flyweight) implementation.
+     * The returned string forms a complete Java class that implements
+     * the given model and the {@link Byteable} contract.
+     *
+     * @param model            description of the value interface
+     * @param nativeClassName  simple name of the class to emit
+     * @return Java source code of the native class
+     */
     static String generateNativeClass(ValueModel model, String nativeClassName) {
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(nativeClassName);
         typeBuilder.addModifiers(PUBLIC);
@@ -52,6 +67,11 @@ final class Generators {
         return result;
     }
 
+    /**
+     * Adds fields and methods required by {@link Byteable} to the native
+     * implementation and delegates to {@link #generateValueCommons(ValueBuilder, ImplType)}
+     * for shared behaviour.
+     */
     private static void generateNativeCommons(ValueBuilder valueBuilder) {
         generateValueCommons(valueBuilder, ImplType.NATIVE);
         ValueModel model = valueBuilder.model;
@@ -116,6 +136,12 @@ final class Generators {
         }
     }
 
+    /**
+     * Inserts behaviour common to both heap and native implementations. This
+     * wires the generated type to the user interface, {@link Copyable} and
+     * {@link BytesMarshallable}, and adds standard methods such as
+     * {@code copyFrom} and marshalling helpers.
+     */
     private static void generateValueCommons(ValueBuilder valueBuilder, ImplType implType) {
         Class<?> valueType = valueBuilder.model.valueType;
         valueBuilder.typeBuilder
@@ -131,6 +157,12 @@ final class Generators {
 //                .addMethod(toStringMethod(valueBuilder, implType));
     }
 
+    /**
+     * Builds the {@code copyFrom} method. Each field is copied individually
+     * using the relevant {@link MemberGenerator}. For native classes the method
+     * optimises the case where the source is another native instance by copying
+     * the underlying bytes directly.
+     */
     private static MethodSpec copyFromMethod(ValueBuilder valueBuilder, ImplType implType) {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("copyFrom")
                 .addAnnotation(Override.class)
@@ -159,6 +191,10 @@ final class Generators {
         return methodBuilder.build();
     }
 
+    /**
+     * Constructs the method that reads the state from a {@link BytesIn}.
+     * Each field delegates the read logic to its {@link MemberGenerator}.
+     */
     private static MethodSpec readMarshallableMethod(ValueBuilder valueBuilder, ImplType implType) {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("readMarshallable")
                 .addAnnotation(Override.class)
@@ -175,6 +211,10 @@ final class Generators {
         return methodBuilder.build();
     }
 
+    /**
+     * Constructs the method that writes the state to a {@link BytesOut}.
+     * Delegates the actual encoding of each field to its generator.
+     */
     private static MethodSpec writeMarshallableMethod(
             ValueBuilder valueBuilder, ImplType implType) {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("writeMarshallable")
@@ -192,6 +232,11 @@ final class Generators {
         return methodBuilder.build();
     }
 
+    /**
+     * Generates the {@code equals} method. Field equality is implemented by
+     * delegating to each field's generator, ensuring the semantics match the
+     * interface definition.
+     */
     private static MethodSpec equalsMethod(ValueBuilder valueBuilder, ImplType implType) {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("equals")
                 .addParameter(Object.class, "obj")
@@ -213,7 +258,9 @@ final class Generators {
     }
 
     /**
-     * Copies google/auto value's strategy of hash code generation
+     * Generates the {@code hashCode} method following the approach used by
+     * Google's AutoValue. Each field contributes to the hash via its
+     * {@link MemberGenerator} specific logic.
      */
     private static MethodSpec hashCodeMethod(ValueBuilder valueBuilder, ImplType implType) {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("hashCode")
@@ -255,6 +302,16 @@ final class Generators {
         return methodBuilder.build();
     }
 
+    /**
+     * Generates the heap backed implementation. The heap class stores field
+     * values directly in normal Java objects and may implement
+     * {@link HeapByteable} when the original interface extends
+     * {@link Byteable}.
+     *
+     * @param model          description of the value interface
+     * @param heapClassName  simple name of the class to emit
+     * @return Java source code of the heap class
+     */
     static String generateHeapClass(ValueModel model, String heapClassName) {
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(heapClassName);
         typeBuilder.addModifiers(PUBLIC);
@@ -274,6 +331,11 @@ final class Generators {
         return result;
     }
 
+    /**
+     * Creates a {@link MethodSpec.Builder} mirroring the given reflective
+     * method. Parameter names are supplied externally as reflection does not
+     * retain them prior to Java 8 compilation with debugging information.
+     */
     static MethodSpec.Builder methodBuilder(Method m, List<String> paramNames) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder(m.getName())
                 .addAnnotation(Override.class)


### PR DESCRIPTION
## Summary
- add class-level description for `Generators`
- document `generateNativeClass`, `generateHeapClass`, `generateNativeCommons`, `generateValueCommons` and helper methods

## Testing
- `mvn -q verify` *(fails: command not found)*