### PR TITLE
Clarify HeapByteable javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/HeapByteable.java
+++ b/src/main/java/net/openhft/chronicle/values/HeapByteable.java
@@ -20,27 +20,49 @@ import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.BytesStore;
 
 /**
- * NOT FOR DIRECT USE. Implements {@link Byteable} by throwing {@link UnsupportedOperationException}
- * from all methods.
+ * Default {@link Byteable} behaviour for heap-backed values. Each method
+ * throws {@link UnsupportedOperationException} because heap instances are not
+ * associated with a {@code BytesStore}.
  */
 @SuppressWarnings("rawtypes")
 public interface HeapByteable extends Byteable {
 
+    /**
+     * Heap objects cannot be bound to a {@link BytesStore}; this method always
+     * throws.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     default void bytesStore(BytesStore bytesStore, long l, long l1) {
         throw new UnsupportedOperationException(getClass() + " doesn't support Byteable interface");
     }
 
+    /**
+     * Heap objects do not have a backing store; this method always throws.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     default BytesStore<?, ?> bytesStore() {
         throw new UnsupportedOperationException(getClass() + " doesn't support Byteable interface");
     }
 
+    /**
+     * Heap values are not memory-mapped so an offset cannot be returned.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     default long offset() {
         throw new UnsupportedOperationException(getClass() + " doesn't support Byteable interface");
     }
 
+    /**
+     * Heap values have no maximum serialised size; this method always throws.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     default long maxSize() {
         throw new UnsupportedOperationException(getClass() + " doesn't support Byteable interface");


### PR DESCRIPTION
## Summary
- document unsupported default implementations for `HeapByteable`
- describe `UnsupportedOperationException` behaviour on each method

## Testing
- `mvn -q verify` *(fails: command not found)*