### PR TITLE
Document IntegerBackedNativeMemberGenerator conversions

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/IntegerBackedNativeMemberGenerator.java
+++ b/src/main/java/net/openhft/chronicle/values/IntegerBackedNativeMemberGenerator.java
@@ -21,8 +21,16 @@ import com.squareup.javapoet.MethodSpec;
 import static java.lang.String.format;
 import static net.openhft.chronicle.values.IntegerFieldModel.*;
 
+/**
+ * Generates native accessors backed by an integer field. The actual
+ * field type is converted to and from this integer when reads and
+ * writes occur. Subclasses provide the conversion logic.
+ */
 abstract class IntegerBackedNativeMemberGenerator extends MemberGenerator {
 
+    /**
+     * Integer field used to hold the raw value in native memory.
+     */
     final IntegerFieldModel backingFieldModel;
 
     IntegerBackedNativeMemberGenerator(
@@ -31,11 +39,18 @@ abstract class IntegerBackedNativeMemberGenerator extends MemberGenerator {
         this.backingFieldModel = backingFieldModel;
     }
 
+    /**
+     * Adds code to convert the supplied integer expression to the accessor
+     * return type.
+     *
+     * @param value expression evaluating to the raw integer
+     */
     abstract void finishGet(
             ValueBuilder valueBuilder, MethodSpec.Builder methodBuilder, String value);
 
     /**
-     * Returns integer value to write (as string)
+     * Converts the argument to its integer representation and returns the
+     * string to be written.
      */
     abstract String startSet(MethodSpec.Builder methodBuilder);
 


### PR DESCRIPTION
## Summary
- explain that IntegerBackedNativeMemberGenerator converts values using an integer backing field
- document backingFieldModel and abstract conversion methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*