### PR TITLE
Add Javadoc to ObjectHeapMemberGenerator

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/ObjectHeapMemberGenerator.java
+++ b/src/main/java/net/openhft/chronicle/values/ObjectHeapMemberGenerator.java
@@ -21,47 +21,76 @@ import java.util.Objects;
 
 import static java.lang.String.format;
 
+/**
+ * Generates accessor logic for object fields held in heap based values.
+ * The code relies on {@link sun.misc.Unsafe} for volatile, ordered and
+ * compare-and-swap operations.
+ */
 class ObjectHeapMemberGenerator extends HeapMemberGenerator {
     ObjectHeapMemberGenerator(FieldModel fieldModel) {
         super(fieldModel);
     }
 
+    /**
+     * Name of the Unsafe routine used for volatile writes.
+     */
     @Override
     String putVolatile() {
         return "putVolatileObject";
     }
 
+    /**
+     * Name of the Unsafe routine used for ordered writes.
+     */
     @Override
     String putOrdered() {
         return "putOrderedObject";
     }
 
+    /**
+     * Name of the Unsafe compare-and-swap routine for object references.
+     */
     @Override
     String compareAndSwap() {
         return "compareAndSwapObject";
     }
 
+    /**
+     * Constant holding the base offset for object arrays.
+     */
     @Override
     String arrayBase() {
         return "ARRAY_OBJECT_BASE_OFFSET";
     }
 
+    /**
+     * Constant holding the index scale for object arrays.
+     */
     @Override
     String arrayScale() {
         return "ARRAY_OBJECT_INDEX_SCALE";
     }
 
+    /**
+     * Heap objects do not require wrapping so the stored value is used as is.
+     */
     @Override
     String wrap(
             ValueBuilder valueBuilder, MethodSpec.Builder methodBuilder, String rawStoredValue) {
         return rawStoredValue;
     }
 
+    /**
+     * No unwrapping is needed for heap objects.
+     */
     @Override
     String unwrap(MethodSpec.Builder methodBuilder, String inputValue) {
         return inputValue;
     }
 
+    /**
+     * Emits a volatile read using {@code getObjectVolatile}.
+     */
     @Override
     public void generateGetVolatile(ValueBuilder valueBuilder, MethodSpec.Builder methodBuilder) {
         methodBuilder.addStatement("return ($T) $N.getObjectVolatile(this, $N)",
@@ -80,6 +109,9 @@ class ObjectHeapMemberGenerator extends HeapMemberGenerator {
                 fieldModel.type, valueBuilder.unsafe(), field, type, type);
     }
 
+    /**
+     * Adds an equality check using {@link java.util.Objects#equals(Object, Object)}.
+     */
     @Override
     void generateEquals(ValueBuilder valueBuilder, MethodSpec.Builder methodBuilder) {
         methodBuilder.addCode("if (!$T.equals($N, other.$N())) return false;\n",
@@ -94,6 +126,9 @@ class ObjectHeapMemberGenerator extends HeapMemberGenerator {
                 Objects.class, field, arrayFieldModel.getOrGetVolatile().getName());
     }
 
+    /**
+     * Returns the expression computing {@code Objects.hashCode} of this field.
+     */
     @Override
     String generateHashCode(ValueBuilder valueBuilder, MethodSpec.Builder methodBuilder) {
         return format("java.util.Objects.hashCode(%s)", field.name);


### PR DESCRIPTION
## Summary
- document ObjectHeapMemberGenerator class
- add method level Javadoc for heap object helpers
- describe volatile access, equality and hash code generation

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*