### PR TITLE
Document SimpleURIClassObject

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/SimpleURIClassObject.java
+++ b/src/main/java/net/openhft/chronicle/values/SimpleURIClassObject.java
@@ -22,12 +22,31 @@ import javax.tools.JavaFileObject;
 import java.io.*;
 import java.net.URI;
 import java.nio.CharBuffer;
+/**
+ * Lightweight {@link JavaFileObject} backed by a {@link URI}.
+ * <p>
+ * {@link MyJavaFileManager} creates instances so the Java compiler can read
+ * already compiled classes from the classpath. Only read operations are
+ * implemented.
+ */
 
 class SimpleURIClassObject implements JavaFileObject {
 
+    /**
+     * Location of the class bytecode.
+     */
     final URI uri;
+    /**
+     * The class being supplied to the compiler.
+     */
     final Class<?> c;
 
+    /**
+     * Creates a wrapper around the given class resource.
+     *
+     * @param uri location of the {@code .class} file
+     * @param c   the class being wrapped
+     */
     protected SimpleURIClassObject(URI uri, Class<?> c) {
         this.uri = uri;
         this.c = c;
@@ -43,6 +62,12 @@ class SimpleURIClassObject implements JavaFileObject {
         return this.toUri().toString();
     }
 
+    /**
+     * Opens the underlying resource for reading.
+     *
+     * @return stream supplying the class bytes
+     * @throws IOException if the resource cannot be opened
+     */
     @Override
     public InputStream openInputStream() throws IOException {
         return uri.toURL().openStream();
@@ -85,12 +110,15 @@ class SimpleURIClassObject implements JavaFileObject {
     public boolean delete() {
         return false;
     }
-
+    /**
+     * This object always represents a compiled class.
+     *
+     * @return {@link Kind#CLASS}
+     */
     @Override
     public Kind getKind() {
         return Kind.CLASS;
     }
-
     @Override
     public boolean isNameCompatible(String simpleName, Kind kind) {
         String baseName = simpleName + kind.extension;


### PR DESCRIPTION
## Summary
- add Javadoc for SimpleURIClassObject fields and methods
- explain purpose relative to MyJavaFileManager

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*