### PR TITLE
Add Javadoc for ValueFieldModel

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/ValueFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/ValueFieldModel.java
@@ -26,21 +26,38 @@ import java.util.Objects;
 import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PRIVATE;
 
+/**
+ * Field model for an embedded value interface. The nested value is stored
+ * directly in the bytes of the outer value. Size and alignment details are
+ * taken from the nested {@link ValueModel}.
+ */
 class ValueFieldModel extends ScalarFieldModel {
     private final NativeMemberGenerator nativeGenerator = new NativeMemberGenerator();
     private ValueModel valueModel;
 
+    /**
+     * Lazily obtains the model of the nested value interface.
+     * The result is cached for the lifetime of this field model.
+     */
     private ValueModel valueModel() {
         if (valueModel == null)
             valueModel = ValueModel.acquire(type);
         return valueModel;
     }
 
+    /**
+     * Width of the nested value in bits. Delegates to
+     * {@link ValueModel#sizeInBytes()}.
+     */
     @Override
     int sizeInBits() {
         return valueModel().sizeInBytes() * 8;
     }
 
+    /**
+     * Alignment requirement in bytes. When unspecified the recommendation of
+     * the nested model is used. The value is at least byte aligned.
+     */
     @Override
     int offsetAlignmentInBytes() {
         if (offsetAlignment == Align.DEFAULT)
@@ -229,9 +246,16 @@ class ValueFieldModel extends ScalarFieldModel {
         };
     }
 
+    /**
+     * Generates native code for the embedded value field. Setters inspect the
+     * source object: if it is a native implementation its bytes are written
+     * directly, otherwise the data are copied via {@link #cachedValue}.
+     */
     final class NativeMemberGenerator extends MemberGenerator {
 
+        /** Temporary object reused when copying from heap implementations. */
         FieldSpec cachedValue;
+        /** Second object used during equality checks. */
         FieldSpec otherCachedValue;
         private Class<?> nativeType;
 


### PR DESCRIPTION
## Summary
- document embedded value field model
- clarify how nested values are sized and aligned
- explain native member generator behaviour

## Testing
- `mvn -q verify` *(fails: mvn not found)*