### PR TITLE
Add Javadoc for alignment test

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/AlignTest.java
+++ b/src/test/java/net/openhft/chronicle/values/AlignTest.java
@@ -22,6 +22,14 @@ import org.junit.Test;
 
 import static net.openhft.chronicle.values.Values.newNativeReference;
 
+/**
+ * Verifies that native values honour alignment rules.
+ *
+ * <p>The {@link DemoOrderVOInterface} contains a double field updated
+ * atomically. This test ensures that the generated implementation places the
+ * field on an eight byte boundary so that {@code addAtomicOrderQty} operates
+ * correctly.</p>
+ */
 public class AlignTest extends ValuesTestCommon {
     @SuppressWarnings("unchecked")
     @Test
@@ -36,16 +44,44 @@ public class AlignTest extends ValuesTestCommon {
     }
 
     @SuppressWarnings("rawtypes")
+    /**
+     * Minimal order definition used to check alignment constraints.
+     *
+     * The order quantity field must be aligned for atomic updates.
+     */
     interface DemoOrderVOInterface extends Byteable {
+        /**
+         * Instrument symbol for the order.
+         */
         CharSequence getSymbol();
 //    public StringBuilder getUsingSymbol(StringBuilder sb);
 
+        /**
+         * Stores the instrument symbol.
+         *
+         * @param symbol text restricted to twenty UTF-8 bytes
+         */
         void setSymbol(@MaxUtf8Length(20) CharSequence symbol);
 
+        /**
+         * Adds {@code toAdd} to the order quantity atomically.
+         *
+         * Alignment of the underlying field is critical so that this method can
+         * use atomic operations provided by Chronicle Bytes.
+         *
+         * @param toAdd increment applied to the quantity
+         * @return the new order quantity
+         */
         double addAtomicOrderQty(double toAdd);
 
+        /**
+         * Returns the current order quantity.
+         */
         double getOrderQty();
 
+        /**
+         * Overwrites the order quantity.
+         */
         void setOrderQty(double orderQty);
 
     }


### PR DESCRIPTION
## Summary
- document `AlignTest` verifying field alignment
- add Javadoc for `DemoOrderVOInterface` and its methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*