### PR TITLE
Add Javadoc for BuySell enum

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/BuySell.java
+++ b/src/test/java/net/openhft/chronicle/values/BuySell.java
@@ -16,9 +16,14 @@
 
 package net.openhft.chronicle.values;
 
-/*
- * Created by peter.lawrey on 03/03/2015.
+/**
+ * Distinguishes the side of a trade used by the tests.
  */
 public enum BuySell {
-    BUY, SELL
+
+    /** Represents a purchase. */
+    BUY,
+
+    /** Represents a sale. */
+    SELL
 }


### PR DESCRIPTION
## Summary
- add concise Javadoc explaining `BuySell`
- document the meaning of each constant
- remove a stale comment

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*