### PR TITLE
Add Javadoc for getUsing with StringBuilder

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/GetUsingStringInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/GetUsingStringInterface.java
@@ -17,7 +17,11 @@
 package net.openhft.chronicle.values;
 
 /**
- * Interface exercising getUsing methods with strings.
+ * Demonstrates the {@code getUsing} pattern with {@link StringBuilder}.
+ * <p>
+ * Each getter copies the field value into the supplied buffer after clearing
+ * it.  This allows callers to reuse a {@code StringBuilder} instance and so
+ * avoid the allocation of a new {@code String} on every read.
  */
 public interface GetUsingStringInterface {
 
@@ -27,7 +31,20 @@ public interface GetUsingStringInterface {
 
     void setSomeStringField(@MaxUtf8Length(64) @NotNull String s);
 
+    /**
+     * Copies {@code someStringField} into the given buffer after truncating it
+     * to length zero.
+     *
+     * @param builder the buffer to reuse; must not be {@code null}
+     */
     void getUsingSomeStringField(StringBuilder builder);
 
+    /**
+     * As {@link #getUsingSomeStringField(StringBuilder)} but returns the buffer
+     * for convenience.
+     *
+     * @param builder the buffer to reuse; must not be {@code null}
+     * @return the supplied {@code builder}
+     */
     StringBuilder getUsingAnotherStringField(StringBuilder builder);
 }


### PR DESCRIPTION
## Summary
- document the `getUsing` pattern with `StringBuilder`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*