### PR TITLE
Document ChronicleValueDate for issue 10 tests

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/issue10/ChronicleValueDate.java
+++ b/src/test/java/net/openhft/chronicle/values/issue10/ChronicleValueDate.java
@@ -16,5 +16,11 @@
 
 package net.openhft.chronicle.values.issue10;
 
+/**
+ * Test interface for Issue 10.
+ *
+ * <p>Extends {@link ChronicleValueType} so the tests can verify that heap and
+ * native implementations are generated correctly.</p>
+ */
 public interface ChronicleValueDate extends ChronicleValueType<ChronicleValueDate> {
 }


### PR DESCRIPTION
## Summary
- add a short Javadoc block for `ChronicleValueDate`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*