### PR TITLE
Add Javadoc for MyEnum accessors

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetMyEnum.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetMyEnum.java
@@ -16,12 +16,26 @@
 
 package net.openhft.chronicle.values;
 
-/*
- * Created by pct25 on 6/4/2015.
+/**
+ * Accessors for storing a {@link MyEnum} value with Chronicle Values.
+ *
+ * <p>The generated implementation keeps the enumeration ordinal in the
+ * backing {@code BytesStore} so that the value may be shared between
+ * threads or processes.</p>
  */
 public interface JavaBeanInterfaceGetMyEnum {
 
+    /**
+     * Reads the enumeration value from the underlying bytes.
+     *
+     * @return the currently stored {@link MyEnum}
+     */
     MyEnum getMyEnum();
 
+    /**
+     * Writes the enumeration into the underlying bytes.
+     *
+     * @param myEnum the value to store, null is not permitted
+     */
     void setMyEnum(MyEnum myEnum);
 }


### PR DESCRIPTION
## Summary
- document usage of `MyEnum` in `JavaBeanInterfaceGetMyEnum`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*