### PR TITLE
Add Javadoc for getUsingString

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsing.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsing.java
@@ -23,5 +23,14 @@ public interface JavaBeanInterfaceGetUsing {
 
     void setString(@MaxUtf8Length(8) String s);
 
+    /**
+     * Writes the stored value into the supplied builder.
+     *
+     * Clears {@code b}, appends the last string set via
+     * {@link #setString(String)}, and returns the builder.
+     *
+     * @param b receptacle for the value; overwritten each call
+     * @return the provided builder for chaining
+     */
     StringBuilder getUsingString(StringBuilder b);
 }


### PR DESCRIPTION
## Summary
- document behaviour of `getUsingString` in `JavaBeanInterfaceGetUsing`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*