### PR TITLE
Add Javadoc for getUsing array interface

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsingAt.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsingAt.java
@@ -18,10 +18,28 @@ package net.openhft.chronicle.values;
 
 import net.openhft.chronicle.core.values.LongValue;
 
+/**
+ * Interface exercising {@code getUsing} operations on a two element array of
+ * {@link LongValue} instances.
+ */
 public interface JavaBeanInterfaceGetUsingAt {
 
+    /**
+     * Writes {@code using} into the slot identified by {@code index}.
+     *
+     * @param index zero-based array index, less than two
+     * @param using value to be copied into the array
+     */
     @Array(length = 2)
     void setItemAt(int index, LongValue using);
 
+    /**
+     * Copies the value stored at the given index into {@code using} to avoid
+     * object creation.
+     *
+     * @param index zero-based array index, less than two
+     * @param using container receiving the value
+     * @return the passed in container for chaining
+     */
     LongValue getUsingItemAt(int index, LongValue using);
 }


### PR DESCRIPTION
## Summary
- document JavaBeanInterfaceGetUsingAt
- explain getUsing array methods

## Testing
- `mvn -q verify` *(fails: mvn not installed)*