### PR TITLE
Add Javadoc for heap getUsing test interface

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsingHeap.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsingHeap.java
@@ -17,7 +17,8 @@
 package net.openhft.chronicle.values;
 
 /**
- * Variant of JavaBeanInterface using heap-backed implementations.
+ * Interface used by tests verifying the {@code getUsing} pattern on a
+ * heap backed implementation.
  */
 public interface JavaBeanInterfaceGetUsingHeap {
 


### PR DESCRIPTION
## Summary
- document JavaBeanInterfaceGetUsingHeap with purpose of getUsing heap tests

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*