### PR TITLE
Document nested fields in NestedA

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/NestedA.java
+++ b/src/test/java/net/openhft/chronicle/values/NestedA.java
@@ -16,7 +16,15 @@
 package net.openhft.chronicle.values;
 
 /**
- * First level nested interface used in tests.
+ * First level nested value containing a text {@code key} and two
+ * {@link NestedB} children named {@code one} and {@code two}.
+ *
+ * <p>Setter parameter names are:</p>
+ * <ul>
+ * <li>{@code key(String key)}</li>
+ * <li>{@code one(NestedB one)}</li>
+ * <li>{@code two(NestedB one)}</li>
+ * </ul>
  */
 public interface NestedA {
     void key(@MaxUtf8Length(64) String key);


### PR DESCRIPTION
## Summary
- clarify NestedA's nested fields in the interface javadoc
- note parameter names used by its setters

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*