### PR TITLE
Document pointer interface

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/pointer/PointedInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/pointer/PointedInterface.java
@@ -20,9 +20,18 @@ import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.values.MaxUtf8Length;
 
 @SuppressWarnings("rawtypes")
+/**
+ * Target for pointer fields in {@link PointingInterface}. Holds text encoded in
+ * UTF-8.
+ */
 public interface PointedInterface extends Byteable {
 
     String getString();
 
+    /**
+     * Stores text with a maximum length of twenty UTF-8 bytes.
+     *
+     * @param s text to store
+     */
     void setString(@MaxUtf8Length(20) String s);
 }


### PR DESCRIPTION
## Summary
- describe `PointedInterface` role for pointer fields
- document UTF-8 size constraint on `setString`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*