### PR TITLE
Document CharSequences helpers

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/CharSequences.java
+++ b/src/main/java/net/openhft/chronicle/values/CharSequences.java
@@ -16,9 +16,27 @@
 
 package net.openhft.chronicle.values;
 
+/**
+ * Small collection of helpers for hashing and comparing {@link CharSequence}
+ * objects.
+ *
+ * <p>The methods deal explicitly with {@code null} values. The
+ * {@link #hashCode(CharSequence)} helper returns {@code 0} for a {@code null}
+ * reference and otherwise produces the same result as
+ * {@link String#hashCode()}. The {@link #equals(CharSequence, CharSequence)}
+ * method mirrors {@link java.util.Objects#equals(Object, Object)} by
+ * considering two {@code null} references equal and carrying out a
+ * character-by-character comparison otherwise.
+ */
 public enum CharSequences {
     ; // none
 
+    /**
+     * Computes the hash code of a character sequence.
+     *
+     * @param cs the sequence to hash, may be {@code null}
+     * @return zero for {@code null}; otherwise the hash of its characters
+     */
     public static int hashCode(CharSequence cs) {
         if (cs == null)
             return 0;
@@ -29,7 +47,14 @@ public enum CharSequences {
         return h;
     }
 
-    // to match Objects.equals(Object o1, Object o2)
+    /**
+     * Character-wise comparison matching
+     * {@link java.util.Objects#equals(Object, Object)}.
+     *
+     * @param left  first sequence, may be {@code null}
+     * @param right second sequence, may be {@code null}
+     * @return {@code true} if both are {@code null} or contain identical characters
+     */
     public static boolean equals(CharSequence left, CharSequence right) {
         if (left == null)
             return right == null;


### PR DESCRIPTION
## Summary
- document null-safe hashing and equality helpers in `CharSequences`
- add javadoc for `hashCode` and `equals`

## Testing
- `mvn -q verify` *(fails: mvn not found)*