### PR TITLE
Clarify primitive sizing rules

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/PrimitiveFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/PrimitiveFieldModel.java
@@ -22,6 +22,16 @@ import java.lang.reflect.Method;
 
 import static net.openhft.chronicle.values.Primitives.widthInBits;
 
+/**
+ * Provides layout rules for primitive fields within a value interface. The
+ * calculations here take the raw primitive width and adjust it for
+ * {@code volatile} or ordered writes so that atomic operations are possible.
+ * <p>
+ * {@link IntegerBackedFieldModel} reuses this logic for domain types encoded as
+ * integers. Subclasses may override {@link #sizeInBits()} when the chosen
+ * storage type must be wider than the logical primitive, typically because of
+ * the concurrency semantics requested by the interface.
+ */
 abstract class PrimitiveFieldModel extends ScalarFieldModel {
 
     @Override


### PR DESCRIPTION
## Summary
- document how PrimitiveFieldModel widens fields for volatile or ordered writes
- explain when IntegerBackedFieldModel reuses these rules

## Testing
- `mvn -q verify` *(fails: command not found)*