### PR TITLE
Clarify boolean width and boxed helper

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/Primitives.java
+++ b/src/main/java/net/openhft/chronicle/values/Primitives.java
@@ -17,7 +17,13 @@
 package net.openhft.chronicle.values;
 
 /**
- * Utility methods for working with Java primitive types.
+ * Utility methods for Java primitive types.
+ *
+ * <p>A boolean is treated as occupying one bit when calculating widths. This
+ * mirrors the layout used by value classes.</p>
+ *
+ * <p>The {@link #boxed(Class)} helper returns the wrapper type for a primitive
+ * and is used in generated code that requires a boxed reference.</p>
  */
 
 final class Primitives {


### PR DESCRIPTION
## Summary
- document that `widthInBits` counts booleans as a single bit
- explain why the `boxed` helper exists

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*