### PR TITLE
Add alignment comment in AlignTest

### DIFF
--- a/src/test/java/net/openhft/chronicle/values/AlignTest.java
+++ b/src/test/java/net/openhft/chronicle/values/AlignTest.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// Verifies field alignment for atomic operations.
 package net.openhft.chronicle.values;
 
 import net.openhft.chronicle.bytes.Byteable;


### PR DESCRIPTION
## Summary
- clarify that AlignTest verifies field alignment for atomic operations

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*