### PR TITLE
Refine JUnit 5 migration fixes and test cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,14 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/net/openhft/chronicle/values/EnumFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/EnumFieldModel.java
@@ -6,7 +6,6 @@ package net.openhft.chronicle.values;
 import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
-import net.openhft.chronicle.core.Jvm;
 
 import java.lang.reflect.Method;
 

--- a/src/main/java/net/openhft/chronicle/values/MyJavaFileManager.java
+++ b/src/main/java/net/openhft/chronicle/values/MyJavaFileManager.java
@@ -151,5 +151,4 @@ public class MyJavaFileManager extends net.openhft.compiler.MyJavaFileManager {
         }
         return super.inferBinaryName(location, file);
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/values/AlignTest.java
+++ b/src/test/java/net/openhft/chronicle/values/AlignTest.java
@@ -18,8 +18,8 @@ import static net.openhft.chronicle.values.Values.newNativeReference;
  * correctly.</p>
  */
 public class AlignTest extends ValuesTestCommon {
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testAlign() {
         DemoOrderVOInterface value = newNativeReference(DemoOrderVOInterface.class);
         long size = value.maxSize();

--- a/src/test/java/net/openhft/chronicle/values/AlignTest.java
+++ b/src/test/java/net/openhft/chronicle/values/AlignTest.java
@@ -5,7 +5,7 @@ package net.openhft.chronicle.values;
 
 import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.BytesStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.values.Values.newNativeReference;
 

--- a/src/test/java/net/openhft/chronicle/values/ComplexValueTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ComplexValueTest.java
@@ -5,7 +5,7 @@ package net.openhft.chronicle.values;
 
 import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.BytesStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 
 import static net.openhft.chronicle.values.Values.newHeapInstance;
 import static net.openhft.chronicle.values.Values.newNativeReference;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ComplexValueTest extends ValuesTestCommon {
 
@@ -44,13 +44,11 @@ public class ComplexValueTest extends ValuesTestCommon {
             Map<String, FieldModel> byName = model.fields()
                     .collect(Collectors.toMap(FieldModel::name, Function.identity()));
 
-            assertTrue("label field present", byName.containsKey("label"));
-            assertTrue("mirrorEnabled field present", byName.containsKey("mirrorEnabled"));
-            assertTrue("label offset should be resolved",
-                    model.fieldBitOffset(byName.get("label")) >= 0);
-            assertTrue("history should allocate extent per element",
-                    model.fieldBitExtent(byName.get("history"))
-                            >= 3 * Long.SIZE);
+            assertTrue(byName.containsKey("label"), "label field present");
+            assertTrue(byName.containsKey("mirrorEnabled"), "mirrorEnabled field present");
+            assertTrue(model.fieldBitOffset(byName.get("label")) >= 0, "label offset should be resolved");
+            assertTrue(model.fieldBitExtent(byName.get("history")) >= 3 * Long.SIZE,
+                    "history should allocate extent per element");
 
             // behaviour assertions
             assertEquals(ComplexValue.Status.ACTIVE, nativeValue.getStatus());

--- a/src/test/java/net/openhft/chronicle/values/CoreValuesTest.java
+++ b/src/test/java/net/openhft/chronicle/values/CoreValuesTest.java
@@ -7,10 +7,10 @@ import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.core.values.*;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.bytes.BytesStore.nativeStoreWithFixedCapacity;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class CoreValuesTest extends ValuesTestCommon {

--- a/src/test/java/net/openhft/chronicle/values/FirstPrimitiveFieldTest.java
+++ b/src/test/java/net/openhft/chronicle/values/FirstPrimitiveFieldTest.java
@@ -5,9 +5,9 @@ package net.openhft.chronicle.values;
 
 import net.openhft.chronicle.core.values.IntValue;
 import net.openhft.chronicle.core.values.LongValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Interface holding a five element array of {@code long} values for field type tests.
@@ -58,16 +58,24 @@ interface FiveBooleanValues {
  * generated proxy.
  */
 interface FiveLongAndBooleanValues {
-    /** Returns the long array view. */
+    /**
+     * Returns the long array view.
+     */
     FiveLongValues getLongValues();
 
-    /** Assigns the long array view. */
+    /**
+     * Assigns the long array view.
+     */
     void setLongValues(FiveLongValues values);
 
-    /** Returns the boolean array view. */
+    /**
+     * Returns the boolean array view.
+     */
     FiveBooleanValues getBooleanValues();
 
-    /** Assigns the boolean array view. */
+    /**
+     * Assigns the boolean array view.
+     */
     void setBooleanValues(FiveBooleanValues values);
 }
 
@@ -79,16 +87,12 @@ public class FirstPrimitiveFieldTest extends ValuesTestCommon {
 
     @Test
     public void firstPrimitiveFieldTest() {
-        assertEquals(int.class, ValueModel.acquire(IntValue.class).firstPrimitiveFieldType());
-        assertEquals(long.class, ValueModel.acquire(LongValue.class).firstPrimitiveFieldType());
-        assertEquals(long.class,
-                ValueModel.acquire(Values.nativeClassFor(LongValue.class))
-                        .firstPrimitiveFieldType());
-        assertEquals(long.class,
-                ValueModel.acquire(FiveLongValues.class).firstPrimitiveFieldType());
-        assertEquals(boolean.class,
-                ValueModel.acquire(FiveBooleanValues.class).firstPrimitiveFieldType());
-        assertEquals(long.class,
-                ValueModel.acquire(FiveLongAndBooleanValues.class).firstPrimitiveFieldType());
+        assertSame(int.class, ValueModel.acquire(IntValue.class).firstPrimitiveFieldType());
+        assertSame(long.class, ValueModel.acquire(LongValue.class).firstPrimitiveFieldType());
+        assertSame(long.class, ValueModel.acquire(Values.nativeClassFor(LongValue.class))
+                .firstPrimitiveFieldType());
+        assertSame(long.class, ValueModel.acquire(FiveLongValues.class).firstPrimitiveFieldType());
+        assertSame(boolean.class, ValueModel.acquire(FiveBooleanValues.class).firstPrimitiveFieldType());
+        assertSame(long.class, ValueModel.acquire(FiveLongAndBooleanValues.class).firstPrimitiveFieldType());
     }
 }

--- a/src/test/java/net/openhft/chronicle/values/UnderscoreFieldNameTest.java
+++ b/src/test/java/net/openhft/chronicle/values/UnderscoreFieldNameTest.java
@@ -3,7 +3,7 @@
  */
 package net.openhft.chronicle.values;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UnderscoreFieldNameTest extends ValuesTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/values/ValueGeneratorTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ValueGeneratorTest.java
@@ -87,8 +87,8 @@ public class ValueGeneratorTest extends ValuesTestCommon {
         assertTrue(mi2.flag());
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
+    @SuppressWarnings("rawtypes")
     public void testGenerateNativeWithGetUsing() throws ClassNotFoundException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         String actual = generateNativeClass(ValueModel.acquire(JavaBeanInterfaceGetUsing.class),
                 ValueModel.simpleName(JavaBeanInterfaceGetUsing.class) + "$$Native");

--- a/src/test/java/net/openhft/chronicle/values/ValueGeneratorTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ValueGeneratorTest.java
@@ -7,7 +7,7 @@ import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.core.values.LongValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
@@ -17,7 +17,7 @@ import static net.openhft.chronicle.values.Generators.generateHeapClass;
 import static net.openhft.chronicle.values.Generators.generateNativeClass;
 import static net.openhft.chronicle.values.Values.newHeapInstance;
 import static net.openhft.chronicle.values.Values.newNativeReference;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static net.openhft.compiler.CompilerUtils.CACHED_COMPILER;
 
 /**

--- a/src/test/java/net/openhft/chronicle/values/ValueInterfaceWithEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ValueInterfaceWithEnumTest.java
@@ -5,10 +5,10 @@ package net.openhft.chronicle.values;
 
 import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.BytesStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.values.ValueInterfaceWithEnumTest.SimpleValueInterface.SVIEnum.SIX;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author ges

--- a/src/test/java/net/openhft/chronicle/values/ValueInterfaceWithEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ValueInterfaceWithEnumTest.java
@@ -35,7 +35,7 @@ public class ValueInterfaceWithEnumTest extends ValuesTestCommon {
         heapValue.copyFrom(nativeValue);
 
         assertEquals(1, heapValue.getId());
-        assertEquals(true, heapValue.getTruth());
+        assertTrue(heapValue.getTruth());
         assertEquals(SIX, heapValue.getSVIEnum());
 
         heapValue.setId(2);
@@ -45,7 +45,7 @@ public class ValueInterfaceWithEnumTest extends ValuesTestCommon {
         nativeValue.copyFrom(heapValue);
 
         assertEquals(2, nativeValue.getId());
-        assertEquals(false, nativeValue.getTruth());
+        assertFalse(nativeValue.getTruth());
         assertEquals(null, nativeValue.getSVIEnum());
     }
 

--- a/src/test/java/net/openhft/chronicle/values/ValueInterfaceWithEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ValueInterfaceWithEnumTest.java
@@ -20,8 +20,8 @@ public class ValueInterfaceWithEnumTest extends ValuesTestCommon {
      * This test will throw an {@link ArrayIndexOutOfBoundsException}. This seems to occur only with Enums having even number of
      * values
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void testValueInterface() {
         SimpleValueInterface nativeValue = Values.newNativeReference(SimpleValueInterface.class);
         int modelSize = ValueModel.acquire(SimpleValueInterface.class).sizeInBytes();

--- a/src/test/java/net/openhft/chronicle/values/ValuesTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/values/ValuesTestCommon.java
@@ -11,8 +11,8 @@ import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import net.openhft.chronicle.core.threads.CleaningThread;
 import net.openhft.chronicle.core.threads.ThreadDump;
 import net.openhft.chronicle.core.time.SystemTimeProvider;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -32,7 +32,13 @@ public class ValuesTestCommon {
     private Map<ExceptionKey, Integer> exceptions;
     private final Map<Predicate<ExceptionKey>, String> expectedExceptions = new LinkedHashMap<>();
 
-    @Before
+    @BeforeEach
+    public void beforeEachValuesTestCommon() {
+        enableReferenceTracing();
+        threadDump();
+        recordExceptions();
+    }
+
     public void enableReferenceTracing() {
         AbstractReferenceCounted.enableReferenceTracing();
     }
@@ -45,7 +51,6 @@ public class ValuesTestCommon {
         AbstractReferenceCounted.assertReferencesReleased();
     }
 
-    @Before
     public void threadDump() {
         threadDump = new ThreadDump();
     }
@@ -54,7 +59,6 @@ public class ValuesTestCommon {
         threadDump.assertNoNewThreads();
     }
 
-    @Before
     public void recordExceptions() {
         exceptions = Jvm.recordExceptions();
     }
@@ -98,7 +102,7 @@ public class ValuesTestCommon {
         }
     }
 
-    @After
+    @AfterEach
     public void afterChecks() {
         SystemTimeProvider.CLOCK = SystemTimeProvider.INSTANCE;
         CleaningThread.performCleanup(Thread.currentThread());

--- a/src/test/java/net/openhft/chronicle/values/VolatileTest.java
+++ b/src/test/java/net/openhft/chronicle/values/VolatileTest.java
@@ -17,8 +17,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * Created by daniel on 11/06/2014.
  */
 public class VolatileTest extends ValuesTestCommon {
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void testGenerateJavaCode() throws ClassNotFoundException, IllegalAccessException, InstantiationException {
 
    /*     try{

--- a/src/test/java/net/openhft/chronicle/values/VolatileTest.java
+++ b/src/test/java/net/openhft/chronicle/values/VolatileTest.java
@@ -5,14 +5,13 @@ package net.openhft.chronicle.values;
 
 import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.BytesStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
 import static net.openhft.chronicle.values.Values.newHeapInstance;
 import static net.openhft.chronicle.values.Values.newNativeReference;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * Created by daniel on 11/06/2014.
@@ -24,14 +23,14 @@ public class VolatileTest extends ValuesTestCommon {
 
    /*     try{
             BadInterface1 jbi = dvg.heapInstance(BadInterface1.class);
-            assertFalse("Should have thrown an IllegalArgumentException", true);
+            assertFalse(true, "Should have thrown an IllegalArgumentException");
         }catch(AssertionError e){
             assertTrue("Throws an IllegalArgumentException", true);
         }
 
         try{
             BadInterface2 jbi = dvg.heapInstance(BadInterface2.class);
-            assertFalse("Should have thrown an IllegalArgumentException", true);
+            assertFalse(true, "Should have thrown an IllegalArgumentException");
         }catch(AssertionError e){
             assertTrue("Throws an IllegalArgumentException", true);
         }
@@ -53,7 +52,7 @@ public class VolatileTest extends ValuesTestCommon {
             assertEquals(3, jbi.getVolatileIntAt(3));
         } catch (AssertionError e) {
             e.printStackTrace();
-            assertFalse("Throws an IllegalArgumentException", true);
+            assertFalse(true, "Throws an IllegalArgumentException");
         }
 
         //Test the native interface
@@ -75,7 +74,7 @@ public class VolatileTest extends ValuesTestCommon {
             assertEquals(3, jbi.getVolatileIntAt(3));
         } catch (AssertionError e) {
             e.printStackTrace();
-            assertFalse("Throws an IllegalArgumentException", true);
+            assertFalse(true, "Throws an IllegalArgumentException");
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/values/issue10/ChronicleValueTypeTest.java
+++ b/src/test/java/net/openhft/chronicle/values/issue10/ChronicleValueTypeTest.java
@@ -5,7 +5,7 @@ package net.openhft.chronicle.values.issue10;
 
 import net.openhft.chronicle.values.Values;
 import net.openhft.chronicle.values.ValuesTestCommon;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChronicleValueTypeTest extends ValuesTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/values/issue9/HeapVsNativeTest.java
+++ b/src/test/java/net/openhft/chronicle/values/issue9/HeapVsNativeTest.java
@@ -32,8 +32,8 @@ public class HeapVsNativeTest extends ValuesTestCommon {
     /**
      * Exercises a native reference and checks it behaves like the heap variant.
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void nativeRef() {
         Entity entity = Values.newNativeReference(Entity.class);
         byte[] bytes = new byte[7];

--- a/src/test/java/net/openhft/chronicle/values/issue9/HeapVsNativeTest.java
+++ b/src/test/java/net/openhft/chronicle/values/issue9/HeapVsNativeTest.java
@@ -9,10 +9,9 @@ import net.openhft.chronicle.values.MaxUtf8Length;
 import net.openhft.chronicle.values.NotNull;
 import net.openhft.chronicle.values.Values;
 import net.openhft.chronicle.values.ValuesTestCommon;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests that heap and native {@link Entity} values hold the same content but

--- a/src/test/java/net/openhft/chronicle/values/pointer/PointerTest.java
+++ b/src/test/java/net/openhft/chronicle/values/pointer/PointerTest.java
@@ -8,10 +8,10 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.values.Values;
 import net.openhft.chronicle.values.ValuesTestCommon;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Objects.requireNonNull;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PointerTest extends ValuesTestCommon {
 


### PR DESCRIPTION
## Summary
- carry the `feature/junit5` branch changes against `develop`
- include the recent JUnit 5 migration fixes and test cleanup already pushed from the workspace
- keep this repo aligned with the broader migration rollout

## Testing
- not run as part of this PR creation step
