### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,5 +1,5 @@
 
-== Copyright 2016-2025 chronicle.software
+== Copyright 2016-2026 chronicle.software
 
 Licensed under the *Apache License, Version 2.0* (the "License");
 you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Chronicle Values
-Copyright 2015-2025 chronicle.software
+Copyright 2015-2026 chronicle.software
 
 Parts of this software are copied from Guice project (https://github.com/google/guice),
 Copyright (C) Google Inc., licensed under Apache 2.0 License

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <packaging>bundle</packaging>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacoco.line.coverage>0.6</jacoco.line.coverage>
         <jacoco.branch.coverage>0.5</jacoco.branch.coverage>

--- a/src/main/java/net/openhft/chronicle/values/Align.java
+++ b/src/main/java/net/openhft/chronicle/values/Align.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Array.java
+++ b/src/main/java/net/openhft/chronicle/values/Array.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/ArrayFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/ArrayFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/BooleanFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/BooleanFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/BytecodeGen.java
+++ b/src/main/java/net/openhft/chronicle/values/BytecodeGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/CharSequenceFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/CharSequenceFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/CharSequences.java
+++ b/src/main/java/net/openhft/chronicle/values/CharSequences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/CodeTemplate.java
+++ b/src/main/java/net/openhft/chronicle/values/CodeTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Copyable.java
+++ b/src/main/java/net/openhft/chronicle/values/Copyable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/DateFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/DateFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/EnumFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/EnumFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Enums.java
+++ b/src/main/java/net/openhft/chronicle/values/Enums.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/FieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/FieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/FieldNullability.java
+++ b/src/main/java/net/openhft/chronicle/values/FieldNullability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/FloatingFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/FloatingFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Generators.java
+++ b/src/main/java/net/openhft/chronicle/values/Generators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Group.java
+++ b/src/main/java/net/openhft/chronicle/values/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/HeapByteable.java
+++ b/src/main/java/net/openhft/chronicle/values/HeapByteable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/HeapMemberGenerator.java
+++ b/src/main/java/net/openhft/chronicle/values/HeapMemberGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/ImplGenerationFailedException.java
+++ b/src/main/java/net/openhft/chronicle/values/ImplGenerationFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/IntegerBackedFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/IntegerBackedFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/IntegerBackedNativeMemberGenerator.java
+++ b/src/main/java/net/openhft/chronicle/values/IntegerBackedNativeMemberGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/IntegerFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/IntegerFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/JavaSourceFromString.java
+++ b/src/main/java/net/openhft/chronicle/values/JavaSourceFromString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/MaxUtf8Length.java
+++ b/src/main/java/net/openhft/chronicle/values/MaxUtf8Length.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/MemberGenerator.java
+++ b/src/main/java/net/openhft/chronicle/values/MemberGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/MethodTemplate.java
+++ b/src/main/java/net/openhft/chronicle/values/MethodTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/MyJavaFileManager.java
+++ b/src/main/java/net/openhft/chronicle/values/MyJavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/NotNull.java
+++ b/src/main/java/net/openhft/chronicle/values/NotNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Nullability.java
+++ b/src/main/java/net/openhft/chronicle/values/Nullability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/NumberHeapMemberGenerator.java
+++ b/src/main/java/net/openhft/chronicle/values/NumberHeapMemberGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/ObjectHeapMemberGenerator.java
+++ b/src/main/java/net/openhft/chronicle/values/ObjectHeapMemberGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Pointer.java
+++ b/src/main/java/net/openhft/chronicle/values/Pointer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/PointerFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/PointerFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/PrimitiveBackedHeapMemberGenerator.java
+++ b/src/main/java/net/openhft/chronicle/values/PrimitiveBackedHeapMemberGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/PrimitiveFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/PrimitiveFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Primitives.java
+++ b/src/main/java/net/openhft/chronicle/values/Primitives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Range.java
+++ b/src/main/java/net/openhft/chronicle/values/Range.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/RangeImpl.java
+++ b/src/main/java/net/openhft/chronicle/values/RangeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/ScalarFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/ScalarFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/SimpleURIClassObject.java
+++ b/src/main/java/net/openhft/chronicle/values/SimpleURIClassObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Utils.java
+++ b/src/main/java/net/openhft/chronicle/values/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/ValueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/values/ValueBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/ValueFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/ValueFieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/ValueModel.java
+++ b/src/main/java/net/openhft/chronicle/values/ValueModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/Values.java
+++ b/src/main/java/net/openhft/chronicle/values/Values.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/main/java/net/openhft/chronicle/values/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/values/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/test/java/net/openhft/chronicle/values/AlignTest.java
+++ b/src/test/java/net/openhft/chronicle/values/AlignTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/BuySell.java
+++ b/src/test/java/net/openhft/chronicle/values/BuySell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/ComplexValue.java
+++ b/src/test/java/net/openhft/chronicle/values/ComplexValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/ComplexValueTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ComplexValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/CoreValuesTest.java
+++ b/src/test/java/net/openhft/chronicle/values/CoreValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/FirstPrimitiveFieldTest.java
+++ b/src/test/java/net/openhft/chronicle/values/FirstPrimitiveFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/GetUsingStringInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/GetUsingStringInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/HasArraysInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/HasArraysInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetAt.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetAt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetDate.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetMyEnum.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetMyEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsing.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsingAt.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsingAt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsingHeap.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceGetUsingHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceMoreThanOneEnums.java
+++ b/src/test/java/net/openhft/chronicle/values/JavaBeanInterfaceMoreThanOneEnums.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/MinimalInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/MinimalInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/MyEnum.java
+++ b/src/test/java/net/openhft/chronicle/values/MyEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/NestedA.java
+++ b/src/test/java/net/openhft/chronicle/values/NestedA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/NestedArrayInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/NestedArrayInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/NestedB.java
+++ b/src/test/java/net/openhft/chronicle/values/NestedB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/NestedInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/NestedInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/StringInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/StringInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/UnderscoreFieldNameInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/UnderscoreFieldNameInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/UnderscoreFieldNameTest.java
+++ b/src/test/java/net/openhft/chronicle/values/UnderscoreFieldNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/UnsignedIntValue.java
+++ b/src/test/java/net/openhft/chronicle/values/UnsignedIntValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/ValueGeneratorTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ValueGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/ValueInterfaceWithEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/values/ValueInterfaceWithEnumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/ValuesTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/values/ValuesTestCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/VolatileTest.java
+++ b/src/test/java/net/openhft/chronicle/values/VolatileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values;
 

--- a/src/test/java/net/openhft/chronicle/values/issue10/ChronicleValueDate.java
+++ b/src/test/java/net/openhft/chronicle/values/issue10/ChronicleValueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values.issue10;
 

--- a/src/test/java/net/openhft/chronicle/values/issue10/ChronicleValueType.java
+++ b/src/test/java/net/openhft/chronicle/values/issue10/ChronicleValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values.issue10;
 

--- a/src/test/java/net/openhft/chronicle/values/issue10/ChronicleValueTypeTest.java
+++ b/src/test/java/net/openhft/chronicle/values/issue10/ChronicleValueTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values.issue10;
 

--- a/src/test/java/net/openhft/chronicle/values/issue9/HeapVsNativeTest.java
+++ b/src/test/java/net/openhft/chronicle/values/issue9/HeapVsNativeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values.issue9;
 

--- a/src/test/java/net/openhft/chronicle/values/pointer/PointedInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/pointer/PointedInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values.pointer;
 

--- a/src/test/java/net/openhft/chronicle/values/pointer/PointerTest.java
+++ b/src/test/java/net/openhft/chronicle/values/pointer/PointerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values.pointer;
 

--- a/src/test/java/net/openhft/chronicle/values/pointer/PointingInterface.java
+++ b/src/test/java/net/openhft/chronicle/values/pointer/PointingInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.values.pointer;
 

--- a/system.properties
+++ b/system.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+# Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 #
 
 # Tracing if resources are closed/released correctly.


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in the project POM so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)