### PR TITLE
docs: close the space in "i. e." and "e. g."

### DIFF
--- a/src/main/java/net/openhft/chronicle/values/CharSequenceFieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/CharSequenceFieldModel.java
@@ -791,7 +791,7 @@ class CharSequenceFieldModel extends ScalarFieldModel {
                 ArrayFieldModel arrayFieldModel, ValueBuilder valueBuilder,
                 MethodSpec.Builder methodBuilder) {
             if (get != null) {
-                // if 1) type of field is not String (i. e. CharSequence or StringBuilder)
+                // if 1) type of field is not String (i.e. CharSequence or StringBuilder)
                 // and 2) there is a getUsing() method
                 // the shortcut copy: this.setField(from.getField()) (*), when the from object is
                 // a native impl, does double contents copy: from native memory to from's cached SB,

--- a/src/main/java/net/openhft/chronicle/values/FieldModel.java
+++ b/src/main/java/net/openhft/chronicle/values/FieldModel.java
@@ -242,7 +242,7 @@ public abstract class FieldModel {
 
     /**
      * Field name as variable name. Not equal to field name, because it could clash with Java
-     * keyword or type name, e. g. getInt()/setInt()
+     * keyword or type name, e.g. getInt()/setInt()
      */
     String varName() {
         return "_" + name;


### PR DESCRIPTION
## Summary
- Replaces `i. e.` with `i.e.` and `e. g.` with `e.g.` in javadoc / AsciiDoc / Markdown.
- Matches conventional English rendering and the style used elsewhere in these repos.
- Purely textual change, no code behaviour affected.

## Test plan
- [ ] Visual diff - only abbreviation spacing changes.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)