### PR TITLE
docs: restore the Values Maven Central badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ Chronicle Software
 :toc: macro
 :toclevels: 3
 
-image:https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-values/badge.svg[link=https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-values]
+image:https://img.shields.io/maven-central/v/net.openhft/chronicle-values.svg[link=https://central.sonatype.com/artifact/net.openhft/chronicle-values]
 image:https://javadoc.io/badge2/net.openhft/chronicle-values/javadoc.svg[link=https://www.javadoc.io/doc/net.openhft/chronicle-values/latest/index.html]
 image:https://img.shields.io/badge/release%20notes-subscribe-brightgreen[link=https://chronicle.software/release-notes/]
 image:https://sonarcloud.io/api/project_badges/measure?project=OpenHFT_Chronicle-Values&metric=alert_status[link=https://sonarcloud.io/dashboard?id=OpenHFT_Chronicle-Values]


### PR DESCRIPTION
Replace the README version badge with [Shields' Maven Central API](https://shields.io/badges/maven-central-version) and link it to [net.openhft:chronicle-values](https://central.sonatype.com/artifact/net.openhft/chronicle-values). [The badge service's migration notice](https://github.com/softwaremill/maven-badges#readme) deprecated the Heroku URL and limited its availability to the end of 2025.

Validation on 9 September 2026: rendered the full README with Asciidoctor 2.0.20 without warnings; checked the rendered badge's destination and the POM coordinate. The badge SVG returned HTTP 200 with a version label, and the artifact page returned HTTP 200 for the intended artifact. `git diff --check` passes. The diff is one README line; Java tests were not rerun for this documentation edit.
