### PR TITLE
Preload JetBrains annotations in MyJavaFileManager for JDK 25+.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,14 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
+            <!--
+                Override parent's `provided` scope: MyJavaFileManager loads
+                NotNull.class and Nullable.class at static init so the runtime
+                compiler can resolve them on inherited chronicle signatures
+                (see #177). The class files must be available to consumers at
+                runtime, not just at compile time.
+            -->
+            <scope>compile</scope>
         </dependency>
 
         <!-- test dependencies -->

--- a/src/main/java/net/openhft/chronicle/values/MyJavaFileManager.java
+++ b/src/main/java/net/openhft/chronicle/values/MyJavaFileManager.java
@@ -55,6 +55,12 @@ public class MyJavaFileManager extends net.openhft.compiler.MyJavaFileManager {
                 Align.class, Array.class, Group.class, MaxUtf8Length.class,
                 net.openhft.chronicle.values.NotNull.class, Range.class,
 
+                // JetBrains annotations referenced on inherited chronicle
+                // signatures; JDK 25+ javac fails symbol completion without
+                // these on the compiler classpath (see #177).
+                org.jetbrains.annotations.NotNull.class,
+                org.jetbrains.annotations.Nullable.class,
+
                 // Bytes classes and interfaces
                 Bytes.class, BytesStore.class, BytesUtil.class,
                 Byteable.class, BytesMarshallable.class,


### PR DESCRIPTION
Root cause: JDK 25 tightened annotation symbol resolution in javac.
Chronicle bytecode (chronicle-bytes, chronicle-core, ...) carries
constant-pool references to org.jetbrains.annotations.NotNull and
Nullable on inherited method signatures. When a downstream consumer
invokes ValueModel runtime code generation, javac walks the full
compile model and fails symbol completion with:

  com.sun.tools.javac.code.Symbol$CompletionFailure:
      class file for NotNull not found

The failure surfaces whenever the value type's classloader differs
from the one holding the JetBrains annotations jar -- a common
arrangement in embedded hosts (Gerrit plugins, OSGi runtimes). JDK
21 silently tolerated the missing symbol; JDK 25 does not.

Fix: preload org.jetbrains.annotations.NotNull.class and
Nullable.class in `MyJavaFileManager`'s static dependencyFileObjects
block, alongside the existing chronicle annotations. The compiler
resolves them from chronicle-values' own classloader, independent of
the value type's classloader. Override the parent POM's `provided`
scope on org.jetbrains:annotations to `compile` so the class files
remain available at runtime in downstream consumers.

Impact: chronicle-values consumers on JDK 25+ no longer need to bundle
the annotations jar or mutate `CompilerUtils`' global classpath via
`addClassPath()` to make runtime code generation work.

Closes #177

