### PR TITLE
CORE-77: Protect file-manager registration against concurrent updates

### DIFF
--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -1,5 +1,6 @@
 = Chronicle Values - Decision Log
 :toc:
+:sectnums:
 :lang: en-GB
 :source-highlighter: rouge
 
@@ -11,6 +12,7 @@ Identifiers follow the `<Scope>-<Tag>-NNN` pattern; numbers are unique within th
 * link:#VAL-FN-101[VAL-FN-101 Value Interfaces as Single Source of Truth]
 * link:#VAL-NFP-111[VAL-NFP-111 Constant-Size Flyweights Backed by Chronicle Bytes]
 * link:#VAL-SPOT-301[VAL-SPOT-301 Code-Review Profile Suppressions for Legacy Generators]
+* link:#VAL-TEST-402[VAL-TEST-402 Concurrent File-Manager Registration]
 
 [[VAL-FN-101]]
 == VAL-FN-101 Value Interfaces as Single Source of Truth
@@ -92,3 +94,20 @@ Rationale for Decision::
 Impact & Consequences::
 * `TODO.adoc` records follow-up tasks tied to the suppression tags and coverage gap.
 * Future generator and testing work must revisit the tagged areas to retire the suppressions and restore standard coverage goals.
+
+[[VAL-TEST-402]]
+== VAL-TEST-402 Concurrent File-Manager Registration
+
+Date:: 2026-09-08
+Context::
+* Chronicle Map's Mac build reported `ConcurrentModificationException` while registering the `LongValue` interface in a shared file manager. Model acquisition caches construction failures, so later consumers can fail too.
+* Requirements: CV-FN-008, CV-TEST-020.
+Decision::
+* Use a concurrent package map and concurrent per-package sets in `MyJavaFileManager`. Resolve class resources outside map remapping callbacks and retain independent snapshots for compiler listings.
+* Test overlapping registration in the same and different packages with latch-controlled class-resource lookup; propagate worker failures to the owning test.
+Alternatives::
+* Making only the outer map concurrent leaves its mutable sets exposed to concurrent registration and listing.
+* Serialising registration around class-resource lookup holds a cache lock while invoking class-loader code.
+Impact::
+* This protects the class-file registry, not every operation of the runtime compiler. Value layouts, public APIs and the model-failure caching policy are unchanged.
+* The additional concurrent collections are used during class registration and compilation, not generated value access.

--- a/src/main/java/net/openhft/chronicle/values/MyJavaFileManager.java
+++ b/src/main/java/net/openhft/chronicle/values/MyJavaFileManager.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Supplies in-memory {@link JavaFileObject} instances to the compiler.
@@ -79,9 +80,14 @@ public class MyJavaFileManager extends net.openhft.compiler.MyJavaFileManager {
      */
     public MyJavaFileManager(Class<?> valueType, StandardJavaFileManager fileManager) {
         super(fileManager);
-        // deep clone dependencyFileObjects
-        fileObjects = new HashMap<>(dependencyFileObjects);
-        fileObjects.replaceAll((p, objects) -> new HashSet<>(objects));
+        //! Registrations can overlap on a shared manager, so both the package map and its sets must be concurrent.
+        //! Copy each dependency set so registering a class cannot mutate another manager's preloaded registry.
+        fileObjects = new ConcurrentHashMap<>(dependencyFileObjects);
+        fileObjects.replaceAll((p, objects) -> {
+            Set<JavaFileObject> copy = ConcurrentHashMap.newKeySet();
+            copy.addAll(objects);
+            return copy;
+        });
         // enrich with valueType's fileObjects
         addFileObjects(fileObjects, valueType);
     }
@@ -97,12 +103,11 @@ public class MyJavaFileManager extends net.openhft.compiler.MyJavaFileManager {
      * Records the class and any interfaces it implements under their packages.
      */
     private static void addFileObjects(Map<String, Set<JavaFileObject>> fileObjects, Class<?> c) {
-        fileObjects.compute(Jvm.getPackageName(c), (p, objects) -> {
-            if (objects == null)
-                objects = new HashSet<>();
-            objects.add(classFileObject(c));
-            return objects;
-        });
+        //! Class-resource lookup invokes class-loader code and may block or re-enter registration.
+        //! Keep it outside map callbacks so resource resolution does not hold the cache's remapping locks.
+        JavaFileObject fileObject = classFileObject(c);
+        fileObjects.computeIfAbsent(Jvm.getPackageName(c), p -> ConcurrentHashMap.newKeySet())
+                .add(fileObject);
 
         Type[] interfaces = c.getGenericInterfaces();
         for (Type superInterface : interfaces) {
@@ -133,6 +138,8 @@ public class MyJavaFileManager extends net.openhft.compiler.MyJavaFileManager {
                 super.list(location, packageName, kinds, recurse);
         Collection<JavaFileObject> packageFileObjects;
         if ((packageFileObjects = fileObjects.get(packageName)) != null) {
+            //! Copy registry entries so later registrations cannot change an already returned listing.
+            //! Iteration is weakly consistent; this does not make multi-class registration atomic.
             packageFileObjects = new ArrayList<>(packageFileObjects);
             delegateFileObjects.forEach(packageFileObjects::add);
             return packageFileObjects;

--- a/src/test/java/net/openhft/chronicle/values/MyJavaFileManagerTest.java
+++ b/src/test/java/net/openhft/chronicle/values/MyJavaFileManagerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.values;
+
+import net.openhft.chronicle.core.values.LongValue;
+import net.openhft.chronicle.values.filemanager.BlockingValue;
+import org.junit.Test;
+
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class MyJavaFileManagerTest {
+
+    @Test
+    public void retainsConcurrentUpdatesToDifferentPackages() throws Exception {
+        assertConcurrentUpdatesRetained(LongValue.class);
+    }
+
+    @Test
+    public void retainsConcurrentUpdatesToTheSamePackage() throws Exception {
+        assertConcurrentUpdatesRetained(BlockingValue.OtherValue.class);
+    }
+
+    private void assertConcurrentUpdatesRetained(Class<?> otherType) throws Exception {
+        BlockingLoader loader = new BlockingLoader();
+        Class<?> blockedType = loader.defineValue();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try (StandardJavaFileManager standard = ToolProvider.getSystemJavaCompiler()
+                .getStandardFileManager(null, null, null)) {
+            // The delegate must not supply the classes whose cache registration is under test.
+            standard.setLocation(StandardLocation.CLASS_PATH, Collections.emptyList());
+            MyJavaFileManager manager = new MyJavaFileManager(MyJavaFileManagerTest.class, standard);
+            Future<?> first = executor.submit(() -> manager.addClassToFileObjects(blockedType));
+            try {
+                assertTrue("First registration did not reach class-resource lookup",
+                        loader.resolving.await(10, TimeUnit.SECONDS));
+                Future<?> second = executor.submit(() -> manager.addClassToFileObjects(otherType));
+                second.get(10, TimeUnit.SECONDS);
+
+                Iterable<JavaFileObject> snapshot = list(manager, blockedType);
+                assertFalse(classNames(manager, snapshot).contains(blockedType.getName()));
+                assertTrue(classNames(manager, list(manager, otherType)).contains(otherType.getName()));
+
+                loader.resume.countDown();
+                first.get(10, TimeUnit.SECONDS);
+
+                assertTrue(classNames(manager, list(manager, blockedType)).contains(blockedType.getName()));
+                assertTrue(classNames(manager, list(manager, otherType)).contains(otherType.getName()));
+                assertFalse("An already returned listing must remain a snapshot",
+                        classNames(manager, snapshot).contains(blockedType.getName()));
+            } finally {
+                loader.resume.countDown();
+            }
+        } finally {
+            loader.resume.countDown();
+            executor.shutdownNow();
+            assertTrue("Registration workers did not terminate", executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    private static Iterable<JavaFileObject> list(MyJavaFileManager manager, Class<?> type) throws IOException {
+        String name = type.getName();
+        return manager.list(StandardLocation.CLASS_PATH, name.substring(0, name.lastIndexOf('.')),
+                EnumSet.of(JavaFileObject.Kind.CLASS), false);
+    }
+
+    private static Set<String> classNames(MyJavaFileManager manager, Iterable<JavaFileObject> files) {
+        Set<String> names = new HashSet<>();
+        files.forEach(file -> names.add(manager.inferBinaryName(StandardLocation.CLASS_PATH, file)));
+        return names;
+    }
+
+    private static final class BlockingLoader extends ClassLoader {
+        private final CountDownLatch resolving = new CountDownLatch(1);
+        private final CountDownLatch resume = new CountDownLatch(1);
+
+        private BlockingLoader() {
+            super(BlockingValue.class.getClassLoader());
+        }
+
+        private Class<?> defineValue() throws IOException {
+            try (InputStream input = BlockingValue.class.getResourceAsStream("BlockingValue.class")) {
+                assertNotNull(input);
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                byte[] buffer = new byte[1024];
+                int length;
+                while ((length = input.read(buffer)) != -1)
+                    output.write(buffer, 0, length);
+                byte[] bytes = output.toByteArray();
+                return defineClass(BlockingValue.class.getName(), bytes, 0, bytes.length);
+            }
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (name.equals(BlockingValue.class.getName().replace('.', '/') + ".class")) {
+                resolving.countDown();
+                try {
+                    assertTrue("Class-resource lookup was not resumed", resume.await(10, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            return super.getResource(name);
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/values/filemanager/BlockingValue.java
+++ b/src/test/java/net/openhft/chronicle/values/filemanager/BlockingValue.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.values.filemanager;
+
+public interface BlockingValue {
+    long getValue();
+
+    void setValue(long value);
+
+    interface OtherValue {
+        int getValue();
+
+        void setValue(int value);
+    }
+}


### PR DESCRIPTION
## Problem

Chronicle Map's [Mac build 316](https://teamcity.chronicle.software/buildConfiguration/Chronicle_ChronicleMap_SnapshotMac/1349114), on OpenHFT/Chronicle-Map#614 at `215114709dd5bb6564ff7416827083c843e77e28`, reports `ConcurrentModificationException` in `MyJavaFileManager.addFileObjects` while creating a `LongValue` model. Model-construction failures are cached, so later Map tests encounter the same exception or lose fixed-size serialisation.

The compiler shares file managers between model-creation threads. The per-manager `HashMap` and its `HashSet` values do not support those overlapping updates and reads.

## Change

- Use a concurrent package map and concurrent per-package sets, retaining independent copies of the preloaded dependency sets.
- Resolve class resources outside map remapping callbacks; class-loader code must not run while a cache remapping lock is held.
- Keep compiler listings as independent snapshots.
- Add two real file-manager regression tests with latch-controlled class-resource lookup: overlapping registration in the same package and in different packages. They check retained registrations, snapshot stability and propagation of worker failures.

This is a new branch from current Values `develop`, `c119f4dff6768230d9a515b5c56b604e1ff91e59`. It does not import OpenHFT/Chronicle-Map#608, alter #614, migrate JUnit, change the POM or redesign model-failure caching. One production class, two test files and a short decision record change. It protects the class-file registry, not every runtime-compiler operation.

## Validation

The CORE-77 revision adds `//!` justification blocks and updates commit metadata, without changing executable code. Clean Java 11 verification was repeated at `d4d9db781158ce0310988bd65c4bbc1828a685db`: 48 tests, no failures/errors/skips, with reruns disabled. The earlier multi-JDK and downstream results below were obtained before this comment-only revision.

- Before the fix, both new regression tests fail on Java 11 with `ExecutionException` caused by `HashMap.compute` / `MyJavaFileManager.addFileObjects` / `ConcurrentModificationException`, matching the Mac failure site. No retries.
- Unchanged Values baseline: clean full Maven verification on Java 11 and Java 25 passes 46 tests, no skips.
- Revised Values: `mvn clean verify -Dsurefire.rerunFailingTestsCount=0` passes on Java 8, 11, 21 and 25: 48 tests per run, no failures/errors/skips.
- Downstream Map: normal Maven verification of the 15 invocations affected in the Mac log passes on Linux/Java 11 against the packaged fixed Values JAR, with both Vintage and Jupiter discovery and no retries or skips. The JAR was installed under a unique local-only validation coordinate; no shared release/snapshot artifact or Map PR was overwritten.
- Full downstream Map `mvn clean verify` with that same artifact passes on Java 11: 1,316 tests, zero failures/errors, 82 skips; failing-test reruns disabled. The binary compatibility check also passes.
- The selected 15 Map invocations also pass with the baseline Values artifact under normal Maven execution. These downstream checks establish compatibility; the two new latch-controlled regressions are the discriminating before/after evidence for the race.

These tests reproduce and fix the registry race; they do not establish that every historical Mac failure has the same cause. The actual Mac agent and Windows were not run locally. Java 26+ checks are informational.

Map still resolves Values 2026.2. After this fix is published in an appropriate Values artifact, Map needs to consume it and rerun Mac CI before claiming the downstream build is fixed.

<details>
<summary>Environment and artifact receipt</summary>

Linux x86_64; Maven 3.9.11; OpenJDK 8u502, 11.0.32, 21.0.12 and 25.0.4. All acceptance runs disable failing-test reruns. Map source base: `0c25269da8d12e3e1cd10c7f4c74ae35a017ab2c`.

Values dependencies: Core 2026.6; Bytes 2026.4; Compiler 2026.2; JavaPoet 1.13.0; JUnit 4.13.2; parent/third-party BOM 2026.0; Chronicle BOM 2026.0-SNAPSHOT.

```text
Chronicle BOM SHA-256: 5e9ce529e8aaa9f9930658b2ef59222ebffe164fb8e6d31ce0b4e204cb1d55a0
Fixed Java-11-built Values JAR SHA-256: ffdc8d852cc4f82ce6ca71529dd8264fe85a119ec1e78317e469e6803b848204
Baseline Java-11-built Values JAR SHA-256: c321897fe472a34a9a9c358c5014037eecc9db65af69ea00c548866df8964aa4
```

</details>
