### PR TITLE
CORE-77: Bound inherited interface registration by class identity

### DIFF
--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -13,6 +13,7 @@ Identifiers follow the `<Scope>-<Tag>-NNN` pattern; numbers are unique within th
 * link:#VAL-NFP-111[VAL-NFP-111 Constant-Size Flyweights Backed by Chronicle Bytes]
 * link:#VAL-SPOT-301[VAL-SPOT-301 Code-Review Profile Suppressions for Legacy Generators]
 * link:#VAL-TEST-402[VAL-TEST-402 Concurrent File-Manager Registration]
+* link:#VAL-NFP-112[VAL-NFP-112 Bounded Interface Registration]
 
 [[VAL-FN-101]]
 == VAL-FN-101 Value Interfaces as Single Source of Truth
@@ -111,3 +112,24 @@ Alternatives::
 Impact::
 * This protects the class-file registry, not every operation of the runtime compiler. Value layouts, public APIs and the model-failure caching policy are unchanged.
 * The additional concurrent collections are used during class registration and compilation, not generated value access.
+
+[[VAL-NFP-112]]
+== VAL-NFP-112 Bounded Interface Registration
+
+Date:: 2026-09-08
+Context::
+* Registering a layered diamond with 26 distinct interfaces retained 12,287 class-file wrappers. Repeated registration also retained fresh wrappers for the same class.
+* Requirements: CV-NFP-011, CV-NFP-013, CV-TEST-020, CV-TEST-021.
+Decision::
+* Key each package's concurrent registry by Class identity, including its defining loader. Retain one class-file wrapper per class per manager.
+* Track visited classes within each call, bounding traversal by distinct reachable classes and inheritance edges rather than inheritance paths.
+* Reuse already resolved entries but still traverse their parents. Another caller may have published a child before completing its parents, or failed while resolving a parent.
+Alternatives::
+* Deduplicate wrappers only :: Retention improves, but repeated traversal and resource lookup remain.
+* Return immediately for a cached child :: A concurrent or previously failed registration can leave its parents unavailable when the later call returns.
+* Share a global visited set or key by binary name :: This can mix managers or defining class loaders.
+Impact::
+* Each call allocates a temporary visited set. Resource lookup remains outside cache callbacks; overlapping callers may resolve the same missing resource, but retain only one wrapper.
+* Both mutable cache levels remain concurrent and independently copied per manager. Returned listings remain copies, not atomic snapshots of concurrent multi-class registration.
+* Tests cover retained entries and lookup counts, bounded cache operations, seeded valid inheritance graphs, class-loader identity, retry, snapshot stability and concurrent completion.
+* This is separate from the race repair in PR #180. Public APIs, value layouts, model-failure caching and the POM are unchanged.

--- a/src/main/java/net/openhft/chronicle/values/MyJavaFileManager.java
+++ b/src/main/java/net/openhft/chronicle/values/MyJavaFileManager.java
@@ -39,7 +39,7 @@ public class MyJavaFileManager extends net.openhft.compiler.MyJavaFileManager {
      * Populated once in the static block below and shared across all
      * instances.
      */
-    private static final Map<String, Set<JavaFileObject>> dependencyFileObjects = new HashMap<>();
+    private static final Map<String, Map<Class<?>, JavaFileObject>> dependencyFileObjects = new HashMap<>();
 
     /*
      * Preloads {@code dependencyFileObjects} with Chronicle classes used by
@@ -72,7 +72,7 @@ public class MyJavaFileManager extends net.openhft.compiler.MyJavaFileManager {
      * {@code dependencyFileObjects}.  Additional classes for the target
      * interface are recorded here so they are visible to the compiler.
      */
-    private final Map<String, Set<JavaFileObject>> fileObjects;
+    private final Map<String, Map<Class<?>, JavaFileObject>> fileObjects;
 
     /**
      * Creates a manager that serves the given {@code valueType} and all
@@ -80,20 +80,17 @@ public class MyJavaFileManager extends net.openhft.compiler.MyJavaFileManager {
      */
     public MyJavaFileManager(Class<?> valueType, StandardJavaFileManager fileManager) {
         super(fileManager);
-        //! Registrations can overlap on a shared manager, so both the package map and its sets must be concurrent.
-        //! Copy each dependency set so registering a class cannot mutate another manager's preloaded registry.
+        //! Registrations can overlap on a shared manager, so both map levels must be concurrent.
+        //! Copy each package map so registering a class cannot mutate another manager's preloaded registry.
         fileObjects = new ConcurrentHashMap<>(dependencyFileObjects);
-        fileObjects.replaceAll((p, objects) -> {
-            Set<JavaFileObject> copy = ConcurrentHashMap.newKeySet();
-            copy.addAll(objects);
-            return copy;
-        });
+        fileObjects.replaceAll((p, objects) -> new ConcurrentHashMap<>(objects));
         // enrich with valueType's fileObjects
         addFileObjects(fileObjects, valueType);
     }
 
     /**
-     * Adds the class so later compilations can reference it.
+     * Adds the class and its inherited interfaces, retaining one object per class identity.
+     * Concurrent calls may resolve the same resource before either publishes it.
      */
     public void addClassToFileObjects(Class<?> c) {
         addFileObjects(fileObjects, c);
@@ -102,17 +99,36 @@ public class MyJavaFileManager extends net.openhft.compiler.MyJavaFileManager {
     /**
      * Records the class and any interfaces it implements under their packages.
      */
-    private static void addFileObjects(Map<String, Set<JavaFileObject>> fileObjects, Class<?> c) {
-        //! Class-resource lookup invokes class-loader code and may block or re-enter registration.
-        //! Keep it outside map callbacks so resource resolution does not hold the cache's remapping locks.
-        JavaFileObject fileObject = classFileObject(c);
-        fileObjects.computeIfAbsent(Jvm.getPackageName(c), p -> ConcurrentHashMap.newKeySet())
-                .add(fileObject);
+    private static void addFileObjects(Map<String, Map<Class<?>, JavaFileObject>> fileObjects, Class<?> c) {
+        addFileObjects(fileObjects, c, new HashSet<>());
+    }
 
+    private static void addFileObjects(Map<String, Map<Class<?>, JavaFileObject>> fileObjects,
+                                       Class<?> c, Set<Class<?>> visited) {
+        //! A diamond reaches shared ancestors through several paths; tracking a visit per call bounds
+        //! traversal by distinct classes and inheritance edges rather than the number of paths.
+        if (!visited.add(c))
+            return;
+
+        //! Fresh wrappers have identity equality, so a wrapper set retains duplicates of the same class.
+        //! Class keys deduplicate registrations without merging equal binary names from different defining loaders.
+        String packageName = Jvm.getPackageName(c);
+        Map<Class<?>, JavaFileObject> packageObjects = fileObjects.get(packageName);
+        if (packageObjects == null || !packageObjects.containsKey(c)) {
+            //! Class-resource lookup invokes class-loader code and may block or re-enter registration.
+            //! Keep it outside map callbacks so resource resolution does not hold the cache's remapping locks.
+            //! Concurrent cold lookups may overlap; putIfAbsent retains just one wrapper for this class.
+            JavaFileObject fileObject = classFileObject(c);
+            fileObjects.computeIfAbsent(packageName, p -> new ConcurrentHashMap<>())
+                    .putIfAbsent(c, fileObject);
+        }
+
+        //! A cached child can belong to an incomplete or failed registration; it is not a completion marker.
+        //! Traverse its parents even on a cache hit so this call can complete the inherited dependency closure.
         Type[] interfaces = c.getGenericInterfaces();
         for (Type superInterface : interfaces) {
             Class<?> rawInterface = ValueModel.rawInterface(superInterface);
-            addFileObjects(fileObjects, rawInterface);
+            addFileObjects(fileObjects, rawInterface, visited);
         }
     }
 
@@ -136,11 +152,11 @@ public class MyJavaFileManager extends net.openhft.compiler.MyJavaFileManager {
             throws IOException {
         Iterable<JavaFileObject> delegateFileObjects =
                 super.list(location, packageName, kinds, recurse);
-        Collection<JavaFileObject> packageFileObjects;
-        if ((packageFileObjects = fileObjects.get(packageName)) != null) {
+        Map<Class<?>, JavaFileObject> packageObjects = fileObjects.get(packageName);
+        if (packageObjects != null) {
             //! Copy registry entries so later registrations cannot change an already returned listing.
             //! Iteration is weakly consistent; this does not make multi-class registration atomic.
-            packageFileObjects = new ArrayList<>(packageFileObjects);
+            Collection<JavaFileObject> packageFileObjects = new ArrayList<>(packageObjects.values());
             delegateFileObjects.forEach(packageFileObjects::add);
             return packageFileObjects;
         } else {

--- a/src/test/java/net/openhft/chronicle/values/MyJavaFileManagerRegistrationLoad.java
+++ b/src/test/java/net/openhft/chronicle/values/MyJavaFileManagerRegistrationLoad.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.values;
+
+import org.junit.rules.TemporaryFolder;
+
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static net.openhft.chronicle.values.RegistrationTestSupport.*;
+import static org.junit.Assert.*;
+
+/**
+ * Opt-in bounded registration/listing load, not a microbenchmark or a wall-clock CI gate.
+ * Arguments: shared|isolated|cold, worker count (1-8), measured batches (1-100).
+ * Run cold compilation in its own JVM: the runtime compiler retains generated sources.
+ */
+public final class MyJavaFileManagerRegistrationLoad {
+    private MyJavaFileManagerRegistrationLoad() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        String scenario = args.length > 0 ? args[0] : "shared";
+        int threads = args.length > 1 ? Integer.parseInt(args[1]) : 4;
+        int batches = args.length > 2 ? Integer.parseInt(args[2]) : 5;
+        if (!(scenario.equals("shared") || scenario.equals("isolated") || scenario.equals("cold"))
+                || threads < 1 || threads > 8 || batches < 1 || batches > 100)
+            throw new IllegalArgumentException("Expected shared|isolated|cold, 1-8 workers, 1-100 batches");
+        Map<String, String> sources = diamond(4);
+        if (scenario.equals("isolated")) {
+            sources.clear();
+            for (int i = 0; i < 128; i++)
+                addInterface(sources, PACKAGE + ".p" + (i % 8) + ".Isolated" + i,
+                        "", "int getValue(); void setValue(int value);");
+        }
+        TemporaryFolder temporary = TemporaryFolder.builder().assureDeletion().build();
+        temporary.create();
+        try (Loader loader = compile(temporary.newFolder(), sources)) {
+            if (scenario.equals("cold")) {
+                Class<?> leaf = loader.type(PACKAGE + ".Left4");
+                Object value = Values.newHeapInstance(leaf);
+                leaf.getMethod("setValue", int.class).invoke(value, 42);
+                assertEquals(42, leaf.getMethod("getValue").invoke(value));
+                System.out.println("Cold Values heap compilation: diamond interface passed getter/setter round trip");
+                return;
+            }
+            List<Class<?>> registrations = new ArrayList<>();
+            for (int i = 0; i < 128; i++)
+                registrations.add(loader.type(scenario.equals("shared") ? PACKAGE + ".Left4"
+                        : PACKAGE + ".p" + (i % 8) + ".Isolated" + i));
+            Set<Class<?>> expected = new HashSet<>();
+            Set<String> packages = new TreeSet<>();
+            for (Class<?> type : registrations)
+                expected.addAll(closure(type));
+            for (Class<?> type : expected)
+                packages.add(type.getName().substring(0, type.getName().lastIndexOf('.')));
+            System.out.println("JVM: " + System.getProperty("java.runtime.version"));
+            System.out.println("Registry: " + MyJavaFileManager.class.getProtectionDomain().getCodeSource().getLocation());
+            System.out.println("scenario,workers,batch,registrations,batch_ms,p95_registration_us,resource_lookups,retained_objects,distinct_classes");
+            for (int batch = -3; batch < batches; batch++) {
+                loader.lookups.values().forEach(count -> count.set(0));
+                try (StandardJavaFileManager standard = emptyDelegate();
+                     Workers pool = new Workers(threads)) {
+                    MyJavaFileManager manager = new MyJavaFileManager(Values.class, standard);
+                    CountDownLatch ready = new CountDownLatch(threads);
+                    CountDownLatch start = new CountDownLatch(1);
+                    List<Future<List<Long>>> futures = new ArrayList<>();
+                    for (int worker = 0; worker < threads; worker++) {
+                        int offset = worker;
+                        futures.add(pool.executor.submit(() -> {
+                            List<Long> latencies = new ArrayList<>();
+                            ready.countDown();
+                            assertTrue(start.await(10, TimeUnit.SECONDS));
+                            for (int i = offset; i < registrations.size(); i += threads) {
+                                long started = System.nanoTime();
+                                manager.addClassToFileObjects(registrations.get(i));
+                                latencies.add(System.nanoTime() - started);
+                            }
+                            return latencies;
+                        }));
+                    }
+                    assertTrue(ready.await(10, TimeUnit.SECONDS));
+                    long started = System.nanoTime();
+                    start.countDown();
+                    List<Iterable<JavaFileObject>> snapshots = new ArrayList<>();
+                    List<List<Class<?>>> snapshotClasses = new ArrayList<>();
+                    for (int i = 0; i < 16; i++) {
+                        Iterable<JavaFileObject> snapshot = list(manager, packages.iterator().next());
+                        snapshots.add(snapshot);
+                        snapshotClasses.add(classes(snapshot));
+                    }
+                    List<Long> latencies = new ArrayList<>();
+                    for (Future<List<Long>> future : futures)
+                        latencies.addAll(future.get(30, TimeUnit.SECONDS));
+                    List<Class<?>> actual = new ArrayList<>();
+                    for (String packageName : packages)
+                        actual.addAll(classes(list(manager, packageName)));
+                    long elapsed = System.nanoTime() - started;
+                    assertEquals(expected, new HashSet<>(actual));
+                    for (int i = 0; i < snapshots.size(); i++)
+                        assertEquals(snapshotClasses.get(i), classes(snapshots.get(i)));
+                    // Count duplicates rather than rejecting them, so the same harness can measure the baseline.
+                    int lookups = loader.lookups.values().stream().mapToInt(count -> count.get()).sum();
+                    Collections.sort(latencies);
+                    if (batch >= 0)
+                        System.out.printf(Locale.ROOT, "%s,%d,%d,%d,%.3f,%.3f,%d,%d,%d%n",
+                                scenario, threads, batch, registrations.size(), elapsed / 1e6,
+                                latencies.get((latencies.size() * 95 - 1) / 100) / 1e3,
+                                lookups, actual.size(), expected.size());
+                }
+            }
+        } finally {
+            temporary.delete();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/values/MyJavaFileManagerRegistrationTest.java
+++ b/src/test/java/net/openhft/chronicle/values/MyJavaFileManagerRegistrationTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.values;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static net.openhft.chronicle.values.RegistrationTestSupport.*;
+import static org.junit.Assert.*;
+
+public class MyJavaFileManagerRegistrationTest {
+    @Rule
+    public final TemporaryFolder temporary = TemporaryFolder.builder().assureDeletion().build();
+
+    @Test
+    public void resolvesAndRetainsEachInheritedClassOnlyOnce() throws Exception {
+        try (Loader loader = compile(temporary.newFolder(), diamond(4));
+             StandardJavaFileManager standard = emptyDelegate()) {
+            MyJavaFileManager manager = new MyJavaFileManager(Values.class, standard);
+            Class<?> leaf = loader.type(PACKAGE + ".Left4");
+            Set<Class<?>> expected = closure(leaf);
+            for (int i = 0; i < 10; i++)
+                manager.addClassToFileObjects(leaf);
+            assertRegistry(manager, expected);
+            for (Class<?> type : expected)
+                assertEquals(type.getName(), 1, loader.lookups(type));
+        }
+    }
+
+    @Test
+    public void traversesCachedDiamondsInBoundedWork() throws Exception {
+        try (Loader loader = compile(temporary.newFolder(), diamond(8));
+             StandardJavaFileManager standard = emptyDelegate()) {
+            Class<?> leaf = loader.type(PACKAGE + ".Left8");
+            MyJavaFileManager manager = new MyJavaFileManager(leaf, standard);
+            // Count real cache operations without adding a production instrumentation hook.
+            Field field = MyJavaFileManager.class.getDeclaredField("fileObjects");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> original = (Map<String, Object>) field.get(manager);
+            CountingMap counted = new CountingMap(original);
+            Method register = MyJavaFileManager.class.getDeclaredMethod("addFileObjects", Map.class, Class.class);
+            register.setAccessible(true);
+            register.invoke(null, counted, leaf);
+            assertTrue("Cache operations follow inheritance paths: " + counted.operations,
+                    counted.operations.get() <= 2 * closure(leaf).size());
+        }
+    }
+
+    @Test
+    public void preservesClassLoaderIdentity() throws Exception {
+        Map<String, String> sources = diamond(0);
+        try (Loader first = compile(temporary.newFolder(), sources);
+             Loader second = compile(temporary.newFolder(), sources);
+             StandardJavaFileManager standard = emptyDelegate()) {
+            MyJavaFileManager manager = new MyJavaFileManager(Values.class, standard);
+            Class<?> firstRoot = first.type(PACKAGE + ".Root");
+            Class<?> secondRoot = second.type(PACKAGE + ".Root");
+            assertNotSame(firstRoot, secondRoot);
+            manager.addClassToFileObjects(firstRoot);
+            manager.addClassToFileObjects(secondRoot);
+            assertRegistry(manager, new HashSet<>(Arrays.asList(firstRoot, secondRoot)));
+        }
+    }
+
+    @Test
+    public void keepsPreloadedPackagesIndependentBetweenManagers() throws Exception {
+        String markerName = "net.openhft.chronicle.values.RegistrationMarker";
+        Map<String, String> sources = new LinkedHashMap<>();
+        addInterface(sources, markerName, "", "");
+        try (Loader loader = compile(temporary.newFolder(), sources);
+             StandardJavaFileManager firstDelegate = emptyDelegate();
+             StandardJavaFileManager secondDelegate = emptyDelegate();
+             StandardJavaFileManager thirdDelegate = emptyDelegate()) {
+            MyJavaFileManager first = new MyJavaFileManager(Values.class, firstDelegate);
+            MyJavaFileManager second = new MyJavaFileManager(Values.class, secondDelegate);
+            Class<?> marker = loader.type(markerName);
+            first.addClassToFileObjects(marker);
+            MyJavaFileManager third = new MyJavaFileManager(Values.class, thirdDelegate);
+            for (MyJavaFileManager manager : Arrays.asList(first, second, third)) {
+                List<Class<?>> registered = classes(list(manager, "net.openhft.chronicle.values"));
+                assertTrue(registered.contains(Values.class));
+                assertEquals(manager == first, registered.contains(marker));
+            }
+        }
+    }
+
+    @Test
+    public void retriesParentsAfterAnEarlierResourceFailure() throws Exception {
+        try (Loader loader = compile(temporary.newFolder(), diamond(2));
+             StandardJavaFileManager standard = emptyDelegate()) {
+            MyJavaFileManager manager = new MyJavaFileManager(Values.class, standard);
+            Class<?> leaf = loader.type(PACKAGE + ".Left2");
+            loader.failNext.set(Loader.resourceName(PACKAGE + ".Root"));
+            IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> manager.addClassToFileObjects(leaf));
+            assertTrue(failure.getMessage().startsWith("Injected resource failure:"));
+            manager.addClassToFileObjects(leaf);
+            assertRegistry(manager, closure(leaf));
+            assertEquals("Already resolved child", 1, loader.lookups(leaf));
+        }
+    }
+
+    @Test
+    public void completesParentsWhileAnotherRegistrationIsBlocked() throws Exception {
+        try (Loader loader = compile(temporary.newFolder(), diamond(2));
+             StandardJavaFileManager standard = emptyDelegate();
+             Workers workers = new Workers(2)) {
+            ExecutorService executor = workers.executor;
+            MyJavaFileManager manager = new MyJavaFileManager(Values.class, standard);
+            Class<?> leaf = loader.type(PACKAGE + ".Left2");
+            loader.blockNext.set(Loader.resourceName(PACKAGE + ".Root"));
+            Future<?> first = executor.submit(() -> manager.addClassToFileObjects(leaf));
+            try {
+                assertTrue(loader.blocked.await(10, TimeUnit.SECONDS));
+                Future<?> second = executor.submit(() -> manager.addClassToFileObjects(leaf));
+                second.get(10, TimeUnit.SECONDS);
+                assertRegistry(manager, closure(leaf));
+            } finally {
+                loader.resume.countDown();
+                first.get(10, TimeUnit.SECONDS);
+            }
+            assertRegistry(manager, closure(leaf));
+        }
+    }
+
+    @Test
+    public void retainsUniqueRegistrationsUnderContention() throws Exception {
+        try (Loader loader = compile(temporary.newFolder(), generated(180L, 24, 4));
+             StandardJavaFileManager standard = emptyDelegate();
+             Workers pool = new Workers(4)) {
+            ExecutorService executor = pool.executor;
+            MyJavaFileManager manager = new MyJavaFileManager(Values.class, standard);
+            Class<?> root = loader.type(PACKAGE + ".Root");
+            manager.addClassToFileObjects(root);
+            Iterable<JavaFileObject> before = list(manager, PACKAGE);
+            List<Class<?>> beforeClasses = classes(before);
+            List<Class<?>> types = new ArrayList<>();
+            Set<Class<?>> expected = new HashSet<>();
+            for (int i = 0; i < 24; i++) {
+                Class<?> type = loader.type(PACKAGE + ".p" + (i % 4) + ".Node" + i);
+                types.add(type);
+                expected.addAll(closure(type));
+            }
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<?>> workers = new ArrayList<>();
+            for (int worker = 0; worker < 4; worker++) {
+                List<Class<?>> order = new ArrayList<>(types);
+                Collections.shuffle(order, new Random(worker));
+                workers.add(executor.submit(() -> {
+                    assertTrue(start.await(10, TimeUnit.SECONDS));
+                    for (int round = 0; round < 10; round++)
+                        order.forEach(manager::addClassToFileObjects);
+                    return null;
+                }));
+            }
+            start.countDown();
+            for (int i = 0; i < 32; i++) {
+                List<Class<?>> during = classes(list(manager, PACKAGE));
+                assertTrue(expected.containsAll(during));
+                assertEquals(during.size(), new HashSet<>(during).size());
+            }
+            for (Future<?> worker : workers)
+                worker.get(10, TimeUnit.SECONDS);
+            assertRegistry(manager, expected);
+            assertEquals("Returned snapshot changed", beforeClasses, classes(before));
+        }
+    }
+
+    @Test
+    public void retainsConcurrentAdditionsToPreloadedPackages() throws Exception {
+        Map<String, String> sources = new LinkedHashMap<>();
+        for (int i = 0; i < 96; i++)
+            addInterface(sources, "net.openhft.chronicle.values.RegistrationMarker" + i, "", "");
+        assertConcurrentAdditions(sources);
+    }
+
+    @Test
+    public void retainsConcurrentAdditionsToNewPackages() throws Exception {
+        Map<String, String> sources = new LinkedHashMap<>();
+        for (int i = 0; i < 96; i++)
+            addInterface(sources, PACKAGE + ".RegistrationMarker" + i, "", "");
+        assertConcurrentAdditions(sources);
+    }
+
+    @Test
+    public void retainsConcurrentAdditionsToCollidingPackages() throws Exception {
+        Map<String, String> sources = new LinkedHashMap<>();
+        for (int i = 0; i < 32; i++) {
+            StringBuilder packageName = new StringBuilder(PACKAGE).append('.');
+            // Aa and BB have the same String hash, forcing distinct packages into one cache bin.
+            for (int bit = 0; bit < 5; bit++)
+                packageName.append((i & (1 << bit)) == 0 ? "Aa" : "BB");
+            addInterface(sources, packageName + ".Marker", "", "");
+        }
+        assertConcurrentAdditions(sources);
+    }
+
+    private void assertConcurrentAdditions(Map<String, String> sources) throws Exception {
+        try (Loader loader = compile(temporary.newFolder(), sources);
+             Workers pool = new Workers(8)) {
+            List<Class<?>> types = new ArrayList<>();
+            for (String name : sources.keySet())
+                types.add(loader.type(name));
+            loader.resourceBarrier = new CyclicBarrier(8);
+            int rounds = Integer.getInteger("values.registration.contentionRounds", 8);
+            assertTrue("Bound the contention campaign", rounds > 0 && rounds <= 256);
+            for (int round = 0; round < rounds; round++) {
+                try (StandardJavaFileManager standard = emptyDelegate()) {
+                    MyJavaFileManager manager = new MyJavaFileManager(Values.class, standard);
+                    Set<Class<?>> expected = new HashSet<>(types);
+                    Set<String> packages = new HashSet<>();
+                    for (Class<?> type : types)
+                        packages.add(type.getName().substring(0, type.getName().lastIndexOf('.')));
+                    for (String packageName : packages)
+                        expected.addAll(classes(list(manager, packageName)));
+                    CountDownLatch ready = new CountDownLatch(8);
+                    CountDownLatch start = new CountDownLatch(1);
+                    List<Future<?>> futures = new ArrayList<>();
+                    try {
+                        for (int worker = 0; worker < 8; worker++) {
+                            int offset = worker;
+                            futures.add(pool.executor.submit(() -> {
+                                ready.countDown();
+                                assertTrue(start.await(10, TimeUnit.SECONDS));
+                                // Each wave resolves distinct classes before contending on the cache.
+                                for (int i = offset; i < types.size(); i += 8)
+                                    manager.addClassToFileObjects(types.get(i));
+                                return null;
+                            }));
+                        }
+                        assertTrue(ready.await(10, TimeUnit.SECONDS));
+                        start.countDown();
+                        for (Future<?> future : futures)
+                            future.get(10, TimeUnit.SECONDS);
+                        assertRegistry(manager, expected);
+                    } finally {
+                        start.countDown();
+                        for (Future<?> future : futures)
+                            future.cancel(true);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void seededRegistrationSequencesMatchTheirInterfaceClosure() throws Exception {
+        long[] regressions = {0L, 180L, 842L, 0x5eedL};
+        Random campaign = new Random(180L);
+        int cases = Integer.getInteger("values.registration.fuzzCases", regressions.length);
+        assertTrue("Bound the generated campaign", cases > 0 && cases <= 1024);
+        for (int run = 0; run < cases; run++) {
+            long seed = run < regressions.length ? regressions[run] : campaign.nextLong();
+            Map<String, String> sources = generated(seed, 24, 4);
+            try (Loader loader = compile(temporary.newFolder(), sources);
+                 StandardJavaFileManager standard = emptyDelegate()) {
+                MyJavaFileManager manager = new MyJavaFileManager(Values.class, standard);
+                Set<Class<?>> expected = new HashSet<>();
+                List<Integer> trace = new ArrayList<>();
+                Random random = new Random(seed);
+                for (int step = 0; step < 64; step++) {
+                    int index = random.nextInt(24);
+                    trace.add(index);
+                    Class<?> type = loader.type(PACKAGE + ".p" + (index % 4) + ".Node" + index);
+                    String packageName = type.getName().substring(0, type.getName().lastIndexOf('.'));
+                    Iterable<JavaFileObject> snapshot = list(manager, packageName);
+                    List<Class<?>> snapshotClasses = classes(snapshot);
+                    manager.addClassToFileObjects(type);
+                    expected.addAll(closure(type));
+                    try {
+                        assertRegistry(manager, expected);
+                        assertEquals(snapshotClasses, classes(snapshot));
+                        for (Class<?> registered : expected)
+                            assertEquals(registered.getName(), 1, loader.lookups(registered));
+                    } catch (AssertionError failure) {
+                        throw new AssertionError("Seed " + seed + ", registration trace " + trace
+                                + ", sources " + sources, failure);
+                    }
+                }
+            }
+        }
+    }
+
+    private static final class CountingMap extends ConcurrentHashMap<String, Object> {
+        private static final long serialVersionUID = 1L;
+        private final AtomicInteger operations = new AtomicInteger();
+
+        CountingMap(Map<String, Object> source) {
+            super(source);
+        }
+
+        @Override
+        public Object get(Object key) {
+            operations.incrementAndGet();
+            return super.get(key);
+        }
+
+        @Override
+        public Object computeIfAbsent(String key, Function<? super String, ?> function) {
+            operations.incrementAndGet();
+            return super.computeIfAbsent(key, function);
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/values/RegistrationTestSupport.java
+++ b/src/test/java/net/openhft/chronicle/values/RegistrationTestSupport.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.values;
+
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+final class RegistrationTestSupport {
+    static final String PACKAGE = "net.openhft.chronicle.values.filemanager.generated";
+
+    private RegistrationTestSupport() {
+    }
+
+    static Map<String, String> diamond(int depth) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        addInterface(sources, PACKAGE + ".Root", "", "int getValue(); void setValue(int value);");
+        for (int i = 0; i <= depth; i++) {
+            String parents = i == 0 ? "Root" : "Left" + (i - 1) + ", Right" + (i - 1);
+            addInterface(sources, PACKAGE + ".Left" + i, parents, "");
+            addInterface(sources, PACKAGE + ".Right" + i, parents, "");
+        }
+        return sources;
+    }
+
+    static Map<String, String> generated(long seed, int size, int packages) {
+        Random random = new Random(seed);
+        Map<String, String> sources = new LinkedHashMap<>();
+        List<String> parents = new ArrayList<>();
+        parents.add(PACKAGE + ".Root");
+        addInterface(sources, parents.get(0), "", "int getValue(); void setValue(int value);");
+        addInterface(sources, PACKAGE + ".Generic<T>", "", "");
+        for (int i = 0; i < size; i++) {
+            Set<String> selected = new LinkedHashSet<>();
+            selected.add(parents.get(random.nextInt(parents.size())));
+            selected.add(parents.get(random.nextInt(parents.size())));
+            if (i % 3 == 0)
+                selected.add(PACKAGE + ".Generic<String>");
+            String name = PACKAGE + ".p" + (i % packages) + ".Node" + i;
+            addInterface(sources, name, String.join(", ", selected), "");
+            parents.add(name);
+        }
+        return sources;
+    }
+
+    static void addInterface(Map<String, String> sources, String name, String parents, String body) {
+        int dot = name.lastIndexOf('.');
+        String source = "package " + name.substring(0, dot) + "; public interface "
+                + name.substring(dot + 1) + (parents.isEmpty() ? "" : " extends " + parents)
+                + " { " + body + " }";
+        sources.put(name.replace("<T>", ""), source);
+    }
+
+    static Loader compile(File directory, Map<String, String> sources) throws IOException {
+        List<JavaFileObject> units = new ArrayList<>();
+        sources.forEach((name, source) -> units.add(new SimpleJavaFileObject(
+                URI.create("string:///" + name.replace('.', '/') + ".java"), JavaFileObject.Kind.SOURCE) {
+            @Override
+            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                return source;
+            }
+        }));
+        try (StandardJavaFileManager standard = emptyDelegate()) {
+            standard.setLocation(StandardLocation.CLASS_OUTPUT, Collections.singletonList(directory));
+            assertTrue("Unable to compile generated fixture: " + sources,
+                    ToolProvider.getSystemJavaCompiler().getTask(null, standard, null,
+                            Arrays.asList("-proc:none", "-source", "8", "-target", "8", "-Xlint:-options"),
+                            null, units).call());
+        }
+        return new Loader(directory, sources.keySet());
+    }
+
+    static StandardJavaFileManager emptyDelegate() throws IOException {
+        StandardJavaFileManager standard = ToolProvider.getSystemJavaCompiler()
+                .getStandardFileManager(null, null, null);
+        standard.setLocation(StandardLocation.CLASS_PATH, Collections.emptyList());
+        return standard;
+    }
+
+    static Set<Class<?>> closure(Class<?> type) {
+        Set<Class<?>> result = new HashSet<>();
+        Deque<Class<?>> pending = new ArrayDeque<>();
+        pending.add(type);
+        while (!pending.isEmpty()) {
+            Class<?> next = pending.removeFirst();
+            if (result.add(next))
+                Collections.addAll(pending, next.getInterfaces());
+        }
+        return result;
+    }
+
+    static Iterable<JavaFileObject> list(MyJavaFileManager manager, String packageName) throws IOException {
+        return manager.list(StandardLocation.CLASS_PATH, packageName,
+                EnumSet.of(JavaFileObject.Kind.CLASS), false);
+    }
+
+    static List<Class<?>> classes(Iterable<JavaFileObject> files) {
+        List<Class<?>> classes = new ArrayList<>();
+        for (JavaFileObject file : files)
+            classes.add(((SimpleURIClassObject) file).c);
+        return classes;
+    }
+
+    static void assertRegistry(MyJavaFileManager manager, Set<Class<?>> expected) throws IOException {
+        Set<String> packages = new HashSet<>();
+        for (Class<?> type : expected)
+            packages.add(type.getName().substring(0, type.getName().lastIndexOf('.')));
+        List<Class<?>> actual = new ArrayList<>();
+        for (String packageName : packages)
+            actual.addAll(classes(list(manager, packageName)));
+        assertEquals("Registered class identities", expected, new HashSet<>(actual));
+        assertEquals("Redundant class-file objects", expected.size(), actual.size());
+    }
+
+    static final class Loader extends URLClassLoader {
+        final Map<String, AtomicInteger> lookups = new ConcurrentHashMap<>();
+        final AtomicReference<String> failNext = new AtomicReference<>();
+        final AtomicReference<String> blockNext = new AtomicReference<>();
+        final CountDownLatch blocked = new CountDownLatch(1);
+        final CountDownLatch resume = new CountDownLatch(1);
+        volatile CyclicBarrier resourceBarrier;
+
+        Loader(File directory, Collection<String> names) throws IOException {
+            super(new URL[]{directory.toURI().toURL()}, RegistrationTestSupport.class.getClassLoader());
+            for (String name : names)
+                lookups.put(resourceName(name), new AtomicInteger());
+        }
+
+        Class<?> type(String name) throws ClassNotFoundException {
+            return Class.forName(name, false, this);
+        }
+
+        int lookups(Class<?> type) {
+            return lookups.get(resourceName(type.getName())).get();
+        }
+
+        @Override
+        public URL getResource(String name) {
+            AtomicInteger count = lookups.get(name);
+            if (count != null)
+                count.incrementAndGet();
+            String failure = failNext.get();
+            if (name.equals(failure) && failNext.compareAndSet(failure, null))
+                throw new IllegalStateException("Injected resource failure: " + name);
+            String blocking = blockNext.get();
+            if (name.equals(blocking) && blockNext.compareAndSet(blocking, null)) {
+                blocked.countDown();
+                try {
+                    assertTrue("Resource lookup was not resumed", resume.await(10, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            URL resource = super.getResource(name);
+            CyclicBarrier barrier = resourceBarrier;
+            if (barrier != null && count != null) {
+                try {
+                    barrier.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+            }
+            return resource;
+        }
+
+        static String resourceName(String name) {
+            return name.replace('.', '/') + ".class";
+        }
+    }
+
+    static final class Workers implements AutoCloseable {
+        final ExecutorService executor;
+
+        Workers(int threads) {
+            executor = Executors.newFixedThreadPool(threads);
+        }
+
+        @Override
+        public void close() {
+            executor.shutdownNow();
+            try {
+                assertTrue("Registration workers did not terminate", executor.awaitTermination(10, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Scope

Stacked on #180, at `d4d9db781158ce0310988bd65c4bbc1828a685db`. The base is `fix/concurrent-value-file-cache`; merge #180 first, then update this follow-up onto develop.

Only `MyJavaFileManager` changes production behaviour. The POM, public APIs, generated value layouts and model-failure caching are unchanged. This is not a JUnit migration.

## Change

A wrapper set does not deduplicate classes: every registration constructs a distinct wrapper. Shared ancestors are also revisited through every inheritance path.

- Key package entries by Class identity, preserving defining-loader identity.
- Visit each class's parents once per call: traversal is proportional to reachable classes plus inheritance edges, not inheritance paths.
- Reuse resolved entries, but still complete their parents. A cached child can belong to an in-progress or previously failed registration.
- Preserve independent concurrent maps at both levels, resource lookup outside callbacks, and copied listings. Overlapping calls can still resolve the same missing resource before either publishes it; only one wrapper is retained.

The two existing #180 regressions remain unchanged. New tests cover lookup/retention counts, bounded traversal, loader/manager isolation, retry, concurrent completion, both package creation paths and seeded valid interface graphs. The traversal-count test supplies a counted map to the existing private helper; functional tests exercise the real manager with controlled loaders.

## Verification

The CORE-77 revision adds `//!` justification blocks and updates commit metadata, without changing executable code. Clean Java 11 verification was repeated at `6c0ab25443c254d89b1c5aa912cf33981cb8596c`: 59 tests, no failures/errors/skips, with reruns disabled. The earlier multi-JDK and downstream results below were obtained before this comment-only revision.

All failing-test reruns were disabled.

| Validation | Result |
| --- | --- |
| Full Values clean verification: Java 8, 11, 21 and 25 | 59 tests per JDK; no failures, errors or skips |
| Extended generated campaign, Java 11 | 128 seeds x 64 registration steps; membership, lookup-count and snapshot checks pass |
| Targeted source mutations against actual project tests | All 11 rejected in the final run |
| Full downstream Map verification, Java 11 | 1,316 tests; no failures/errors, 82 skips; binary compatibility passes |
| Isolated cold heap-generation smoke | Diamond getter/setter round trip passes on parent and candidate |

The initial eight new tests produced six failures against #180 before the production change. The final mutation set independently removes traversal tracking, reuse, parent completion, deep copying, each of the three concurrent-map creation choices, parent registration, snapshots, loader identity, and lookup-outside-callback placement.

**Stress qualification:** the inner-map mutations survived earlier short runs. Aligned resource-completion waves and an interpreted-JVM, 256-round profile exposed lost registrations; matching correct-implementation controls passed. The final normal run also caught both. These are observed mutation kills, not deterministic scheduling guarantees or a PIT mutation-score claim.

## Bounded load comparison

Java 11.0.32, Linux x86_64. Each cell uses three fresh JVMs, three warm-up batches and five measured batches per JVM. The same harness checks membership and snapshots on parent/candidate artifacts.

Each batch performs 128 registrations plus listings. The shared case repeatedly registers a ten-interface diamond: retained wrappers fall from **6,016 to 10**. With one worker, resource lookups also fall from 6,016 to 10; overlapping workers can perform additional cold lookups.

| Workload | Workers | Parent median batch, ms | Candidate median batch, ms |
| --- | ---: | ---: | ---: |
| Shared ancestors/repeated registrations | 1 | 86.377 | 0.814 |
| Shared ancestors/repeated registrations | 4 | 28.243 | 1.452 |
| Shared ancestors/repeated registrations | 8 | 22.758 | 2.815 |
| 128 unrelated classes, each registered once | 1 | 3.933 | 3.902 |
| 128 unrelated classes, each registered once | 4 | 2.395 | 2.294 |
| 128 unrelated classes, each registered once | 8 | 1.780 | 2.035 |

The no-sharing control retains/resolves 128 classes in both versions and is slower in the eight-worker sample. This is a bounded diagnostic load receipt, not a JMH microbenchmark, allocation-byte measurement, general speedup guarantee or a wall-clock CI threshold.

## Reproduction

```bash
mvn -B -nsu clean verify -Dsurefire.rerunFailingTestsCount=0 -l registration-verify.log
mvn -B -nsu test -Dtest=MyJavaFileManagerRegistrationTest \
  -Dvalues.registration.fuzzCases=128 \
  -Dsurefire.rerunFailingTestsCount=0 -l registration-fuzz.log
```

For the bounded load harness on JDK 11 (Bash):

```bash
mvn -B -nsu test-compile dependency:build-classpath \
  -DincludeScope=test -Dmdep.outputFile=target/registration-classpath.txt
registration_cp="target/test-classes:target/classes:$(<target/registration-classpath.txt)"
java -ea \
  --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
  --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED \
  --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
  --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED \
  --add-opens=java.base/java.io=ALL-UNNAMED \
  --add-opens=java.base/java.lang=ALL-UNNAMED \
  --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
  --add-opens=java.base/java.util=ALL-UNNAMED \
  --add-opens=jdk.compiler/com.sun.tools.javac=ALL-UNNAMED \
  -cp "$registration_cp" \
  net.openhft.chronicle.values.MyJavaFileManagerRegistrationLoad shared 4 5
```

For an artifact comparison, replace `target/classes` in that classpath with the selected parent/candidate JAR while keeping the same test harness and dependency closure.

The opt-in [load entry point](https://github.com/OpenHFT/Chronicle-Values/blob/6c0ab25443c254d89b1c5aa912cf33981cb8596c/src/test/java/net/openhft/chronicle/values/MyJavaFileManagerRegistrationLoad.java) accepts `shared|isolated|cold`, worker count and measured batch count. Run it in a fresh JVM using the test classpath and the project's standard module exports/opens. Cold mode checks one new interface; it does not run inside the shared unit-test JVM. The extended contention profile uses `values.registration.contentionRounds=256`, optionally with `-Xint`.

Resolved dependencies include Core 2026.6, Bytes 2026.4, Compiler 2026.2, JavaPoet 1.13.0 and JUnit 4.13.2; parent/third-party BOM 2026.0. Chronicle BOM snapshot SHA-256: `5e9ce529e8aaa9f9930658b2ef59222ebffe164fb8e6d31ce0b4e204cb1d55a0`.

## Limits and separate finding

- No local Mac or Windows execution; Java 26+ checks are informational. No claim that Map's Mac build is fixed or that the whole compiler is thread-safe.
- Map validation used a private local Maven coordinate, `2026.3-registration-UmKDvk-SNAPSHOT`, not a published artifact or committed dependency bump.
- An exploratory sequence compiling several temporary-loader Values types fails on both parent and candidate with a missing `Left1` symbol. A shared-JVM smoke fixture also exposed retained compiler-source state. Those wider compiler/loader behaviours are preserved as separate diagnostics, not hidden by retries or repaired in this focused change.
